### PR TITLE
Issue reporting everything as app.php

### DIFF
--- a/Listener/RequestListener.php
+++ b/Listener/RequestListener.php
@@ -51,7 +51,7 @@ class RequestListener
 
         $route = $event->getRequest()->get('_route');
 
-        $this->interactor->setTransactionName($route ?: 'symfony unknow route');
         $this->interactor->setApplicationName($this->newRelic->getName());
+        $this->interactor->setTransactionName($route ?: 'symfony unknown route');
     }
 }


### PR DESCRIPTION
We have just been tracking an issue with newrelic where many of our transactions were being tracked against app.php instead of the route name.

Newrelic's advice was to ensure we always call new relic_set_appname() before any other calls.

I switched the order of the setTransactionName and setApplicationName in Ekino\Bundle\NewRelicBundle\Listener\RequestListener::onCoreRequest() and we now have consistent reporting against route names.

i.e.: 
$this->interactor->setTransactionName($route ?: 'symfony unknow route');
$this->interactor->setApplicationName($this->newRelic->getName());

becomes:

$this->interactor->setApplicationName($this->newRelic->getName());
$this->interactor->setTransactionName($route ?: 'symfony unknow route');

This commit resolves the issue.
