### PR TITLE
Bugfix: Replace some outdated method calls in receipe

### DIFF
--- a/Resources/recipes/newrelic.rb
+++ b/Resources/recipes/newrelic.rb
@@ -29,10 +29,10 @@ namespace :newrelic do
       end
       new_revision = rev
       logger.debug "Uploading deployment to New Relic"
-      pretty_print "--> Notifying New Relic of deployment"
+      capifony_pretty_print "--> Notifying New Relic of deployment"
 
       run "cd #{latest_release} && #{php_bin} #{symfony_console} newrelic:notify-deployment --env=#{symfony_env_prod} --no-debug --revision='#{rev}' --changelog='#{changelog}' --description='#{description}' --user='#{user}'"
-      puts_ok
+      capifony_puts_ok
     rescue Capistrano::CommandError
       logger.info "Unable to notify New Relic of the deployment... skipping"
     end


### PR DESCRIPTION
The orginal PR was pushed 5 months ago. In the meantime capifony (the tool, the receipe was built on top of) changed several methods.

See Ekino/EkinoNewRelicBundle#5
