### PR TITLE
Bugfix: Use local proxy to query repository

### DIFF
--- a/Resources/recipes/newrelic.rb
+++ b/Resources/recipes/newrelic.rb
@@ -12,16 +12,16 @@ namespace :newrelic do
 
       if !changelog
         logger.debug "Getting log of changes for New Relic Deployment details"
-        from_revision = source.next_revision(current_revision)
+        from_revision = source.local.next_revision(current_revision)
         if scm == :git
           log_command = "git log --no-color --pretty=format:'  * %an: %s' --abbrev-commit --no-merges #{previous_revision}..#{real_revision}"
         else
-          log_command = "#{source.log(from_revision)}"
+          log_command = "#{source.local.log(from_revision)}"
         end
         changelog = `#{log_command}`
       end
       if rev.nil?
-        rev = source.query_revision(source.head()) do |cmd|
+        rev = source.local.query_revision(source.local.head()) do |cmd|
           logger.debug "executing locally: '#{cmd}'"
           `#{cmd}`
         end


### PR DESCRIPTION
Well, here we are :smile: As mentioned I integrated the both PRs [1][2] into my fork. There I found two issues.

This one covers the situation, where the repository is on the remote machine. The problem is, that the repository is given as local file path (on the remote machine and thus access the receipe cannot fetch the changelog and such. This PR makes use of the local proxy. That means, that if `:local_repository` is given, it is used instead of `:repository`.

[1] Ekino/EkinoNewRelicBundle#7
[2] Ekino/EkinoNewRelicBundle#5
