### PR TITLE
Adding error notice method

### DIFF
--- a/NewRelic/BlackholeInteractor.php
+++ b/NewRelic/BlackholeInteractor.php
@@ -58,6 +58,13 @@ class BlackholeInteractor implements NewRelicInteractorInterface
     /**
      * {@inheritdoc}
      */
+    public function noticeError($msg)
+    {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function noticeException(\Exception $e)
     {
     }

--- a/NewRelic/LoggingInteractorDecorator.php
+++ b/NewRelic/LoggingInteractorDecorator.php
@@ -89,6 +89,15 @@ class LoggingInteractorDecorator implements NewRelicInteractorInterface
     /**
      * {@inheritdoc}
      */
+    public function noticeError($msg)
+    {
+        $this->log('Sending notice error to New Relic');
+        $this->interactor->noticeError($msg);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function noticeException(\Exception $e)
     {
         $this->log('Sending exception to New Relic');

--- a/NewRelic/NewRelicInteractor.php
+++ b/NewRelic/NewRelicInteractor.php
@@ -72,6 +72,14 @@ class NewRelicInteractor implements NewRelicInteractorInterface
     /**
      * {@inheritdoc}
      */
+    public function noticeError($msg)
+    {
+        newrelic_notice_error($msg);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function noticeException(\Exception $e)
     {
         newrelic_notice_error(null, $e);

--- a/NewRelic/NewRelicInteractorInterface.php
+++ b/NewRelic/NewRelicInteractorInterface.php
@@ -59,6 +59,13 @@ interface NewRelicInteractorInterface
     function disableAutoRUM();
 
     /**
+     * @param string $msg
+     *
+     * @return void
+     */
+    function noticeError($msg);
+
+    /**
      * @param Exception $exception
      *
      * @return void


### PR DESCRIPTION
Adding noticeError($msg) method. Let me know when anything is missing. Thanks

Here is a documentation:
https://newrelic.com/docs/php/the-php-api
