### PR TITLE
Fix outputting browser_timing_header and browser_timing_footer when loggin is on

### DIFF
--- a/NewRelic/LoggingInteractorDecorator.php
+++ b/NewRelic/LoggingInteractorDecorator.php
@@ -87,7 +87,7 @@ class LoggingInteractorDecorator implements NewRelicInteractorInterface
     {
         $this->log('Getting New Relic RUM timing header');
 
-        $this->interactor->getBrowserTimingHeader();
+        return $this->interactor->getBrowserTimingHeader();
     }
 
     /**
@@ -97,7 +97,7 @@ class LoggingInteractorDecorator implements NewRelicInteractorInterface
     {
         $this->log('Getting New Relic RUM timing footer');
 
-        $this->interactor->getBrowserTimingFooter();
+        return $this->interactor->getBrowserTimingFooter();
     }
 
     /**


### PR DESCRIPTION
If the bundle config has `ekino_new_relic.logging: true` then the javascript that sends the browsers events to New Relic is not outputted.
