### PR TITLE
create branch alias

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,5 +18,10 @@
     "autoload": {
         "psr-0": { "Ekino\\Bundle\\NewRelicBundle": "" }
     },
-    "target-dir": "Ekino/Bundle/NewRelicBundle"
+    "target-dir": "Ekino/Bundle/NewRelicBundle",
+    "extra": {
+        "branch-alias": {
+            "dev-master": "1.0-dev"
+        }
+    }
 }


### PR DESCRIPTION
this would allow to depend on branch 1.0.\* instead of dev-master.

btw, depending on symfony/symfony: \* sounds a bit strange. symfony/framework-bundle: >= 2.0, < 2.3 would sound more realistic imo.
