### PR TITLE
Make application_name optional

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -28,7 +28,7 @@ class Configuration implements ConfigurationInterface
         $rootNode
             ->children()
                 ->scalarNode('api_key')->defaultValue(false)->end()
-                ->scalarNode('application_name')->isRequired()->cannotBeEmpty()->end()
+                ->scalarNode('application_name')->defaultValue(null)->end()
                 ->scalarNode('logging')
                     ->defaultFalse()
                     ->validate()

--- a/Listener/RequestListener.php
+++ b/Listener/RequestListener.php
@@ -55,7 +55,9 @@ class RequestListener
 
         $transactionName = $this->transactionNamingStrategy->getTransactionName($event->getRequest());
 
-        $this->interactor->setApplicationName($this->newRelic->getName());
+        if ($this->newRelic->getName()) {
+            $this->interactor->setApplicationName($this->newRelic->getName());
+        }
         $this->interactor->setTransactionName($transactionName);
     }
 }

--- a/README.md
+++ b/README.md
@@ -100,8 +100,8 @@ $bundles = array(
 # app/config/config.yml
 
 ekino_new_relic:
-    // ...
-    application_name: Awesome Application # (mandatory, default value in newrelic is PHP Application)
+    application_name: Awesome Application # default value in newrelic is "PHP Application", or whatever is set
+                                          # as php ini-value
     api_key:                              # New Relic API
     logging: false                        # If true, logs all New Relic interactions to the Symfony log
     instrument: false                     # If true, uses enhanced New Relic RUM instrumentation (see below)


### PR DESCRIPTION
Because there are other ways to set the application name it would be useful, to allow the user the omit `application_name`.
