### PR TITLE
fix NewRelicInteractor::addCustomParameter

### DIFF
--- a/NewRelic/NewRelicInteractor.php
+++ b/NewRelic/NewRelicInteractor.php
@@ -42,7 +42,7 @@ class NewRelicInteractor implements NewRelicInteractorInterface
      */
     public function addCustomParameter($name, $value)
     {
-        newrelic_custom_parameter((string) $name, (string) $value);
+        newrelic_add_custom_parameter((string) $name, (string) $value);
     }
 
     /**


### PR DESCRIPTION
```
Fatal error: Call to undefined function Ekino\Bundle\NewRelicBundle\NewRelic\newrelic_custom_parameter()
```

Looks like there is inconsistence in the New Relic PHP API about custom metrics and custom parameters. There is no method `newrelic_custom_parameter` but [`newrelic_add_custom_parameter`](https://newrelic.com/docs/php/the-php-api).

I read the [release notes PHP agent](https://newrelic.com/docs/releases/php) and didn't find any change about this. So, I hope there is not BC. Can you confirm ?
