### PR TITLE
Make the command independant from the container

### DIFF
--- a/Command/NotifyDeploymentCommand.php
+++ b/Command/NotifyDeploymentCommand.php
@@ -11,7 +11,7 @@
 
 namespace Ekino\Bundle\NewRelicBundle\Command;
 
-use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Input\InputArgument;
@@ -19,8 +19,24 @@ use Symfony\Component\Console\Input\InputOption;
 
 use Ekino\Bundle\NewRelicBundle\NewRelic\NewRelic;
 
-class NotifyDeploymentCommand extends ContainerAwareCommand
+class NotifyDeploymentCommand extends Command
 {
+    /**
+     * @var NewRelic
+     */
+    private $newrelic;
+
+    /**
+     * @param NewRelic $newrelic
+     */
+    public function __construct(NewRelic $newrelic)
+    {
+        $this->newrelic = $newrelic;
+
+        parent::__construct();
+    }
+
+
     /**
      * {@inheritDoc}
      */
@@ -55,7 +71,7 @@ class NotifyDeploymentCommand extends ContainerAwareCommand
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $newrelic = $this->getContainer()->get('ekino.new_relic');
+        $newrelic = $this->newrelic;
 
         $status = $this->performRequest($newrelic->getApiKey(), $this->createPayload($newrelic, $input));
 

--- a/EkinoNewRelicBundle.php
+++ b/EkinoNewRelicBundle.php
@@ -14,6 +14,8 @@ namespace Ekino\Bundle\NewRelicBundle;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Ekino\Bundle\NewRelicBundle\DependencyInjection\Compiler\NewRelicCompilerPass;
+use Symfony\Component\Console\Application;
+use Ekino\Bundle\NewRelicBundle\Command\NotifyDeploymentCommand;
 
 class EkinoNewRelicBundle extends Bundle
 {
@@ -23,5 +25,20 @@ class EkinoNewRelicBundle extends Bundle
     public function build(ContainerBuilder $container)
     {
         $container->addCompilerPass(new NewRelicCompilerPass());
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function registerCommands(Application $application)
+    {
+        parent::registerCommands($application);
+
+        $container = $application->getKernel()->getContainer();
+
+        if ($container->has('ekino.new_relic')) {
+            $newrelic = $container->get('ekino.new_relic');
+            $application->add(new NotifyDeploymentCommand($newrelic));
+        }
     }
 }


### PR DESCRIPTION
The command must not extend the ContainerAwareCommand class to be usable out of symfony full stack framework.
