### PR TITLE
Honour application_name and api_key correctly

### DIFF
--- a/Listener/CommandListener.php
+++ b/Listener/CommandListener.php
@@ -13,6 +13,7 @@ namespace Ekino\Bundle\NewRelicBundle\Listener;
 
 use Symfony\Component\Console\Event\ConsoleCommandEvent;
 use Ekino\Bundle\NewRelicBundle\NewRelic\NewRelicInteractorInterface;
+use Ekino\Bundle\NewRelicBundle\NewRelic\NewRelic;
 
 class CommandListener
 {
@@ -21,12 +22,15 @@ class CommandListener
      */
     protected $interactor;
 
+    protected $newRelic;
+
     /**
      * @param NewRelicInteractorInterface $interactor
      */
-    public function __construct(NewRelicInteractorInterface $interactor)
+    public function __construct(NewRelic $newRelic, NewRelicInteractorInterface $interactor)
     {
         $this->interactor = $interactor;
+        $this->newRelic = $newRelic;
     }
 
     /**
@@ -36,7 +40,9 @@ class CommandListener
     {
         $command = $event->getCommand();
         $input = $event->getInput();
-
+        if ($this->newRelic->getName()) {
+            $this->interactor->setApplicationName($this->newRelic->getName(), $this->newRelic->getApiKey());
+        }
         $this->interactor->setTransactionName($command->getName());
         $this->interactor->enableBackgroundJob();
 

--- a/Listener/RequestListener.php
+++ b/Listener/RequestListener.php
@@ -56,7 +56,7 @@ class RequestListener
         $transactionName = $this->transactionNamingStrategy->getTransactionName($event->getRequest());
 
         if ($this->newRelic->getName()) {
-            $this->interactor->setApplicationName($this->newRelic->getName());
+            $this->interactor->setApplicationName($this->newRelic->getName(), $this->newRelic->getApiKey());
         }
         $this->interactor->setTransactionName($transactionName);
     }

--- a/NewRelic/BlackholeInteractor.php
+++ b/NewRelic/BlackholeInteractor.php
@@ -16,7 +16,7 @@ class BlackholeInteractor implements NewRelicInteractorInterface
     /**
      * {@inheritdoc}
      */
-    public function setApplicationName($name)
+    public function setApplicationName($name, $key = null)
     {
     }
 

--- a/NewRelic/LoggingInteractorDecorator.php
+++ b/NewRelic/LoggingInteractorDecorator.php
@@ -56,10 +56,10 @@ class LoggingInteractorDecorator implements NewRelicInteractorInterface
     /**
      * {@inheritdoc}
      */
-    public function setApplicationName($name)
+    public function setApplicationName($name, $key = null)
     {
         $this->log(sprintf('Setting New Relic Application name to %s', $name));
-        $this->interactor->setApplicationName($name);
+        $this->interactor->setApplicationName($name, $key);
     }
 
     /**

--- a/NewRelic/NewRelicInteractor.php
+++ b/NewRelic/NewRelicInteractor.php
@@ -16,9 +16,9 @@ class NewRelicInteractor implements NewRelicInteractorInterface
     /**
      * {@inheritdoc}
      */
-    public function setApplicationName($name)
+    public function setApplicationName($name, $key = null)
     {
-        newrelic_set_appname($name);
+        newrelic_set_appname($name, $key, true);
     }
 
     /**

--- a/NewRelic/NewRelicInteractorInterface.php
+++ b/NewRelic/NewRelicInteractorInterface.php
@@ -18,7 +18,7 @@ interface NewRelicInteractorInterface
      *
      * @return void
      */
-    function setApplicationName($name);
+    function setApplicationName($name, $key = null);
 
     /**
      * @param string $name

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -48,6 +48,7 @@
         <service id="ekino.new_relic.command_listener" class="Ekino\Bundle\NewRelicBundle\Listener\CommandListener">
             <tag name="kernel.event_listener" event="console.command" method="onConsoleCommand" priority="0"/>
 
+            <argument type="service" id="ekino.new_relic" />
             <argument type="service" id="ekino.new_relic.interactor" />
         </service>
 


### PR DESCRIPTION
application_name was not set in ConsoleCommand
api_key was never set (or I didn't find it, how it should work)

This patch should fix that.
