### PR TITLE
Drop unused ignoreRoutes and ignoreUrls from RequestListener

### DIFF
--- a/DependencyInjection/EkinoNewRelicExtension.php
+++ b/DependencyInjection/EkinoNewRelicExtension.php
@@ -92,7 +92,7 @@ class EkinoNewRelicExtension extends Extension
         }
 
         $container->getDefinition('ekino.new_relic.request_listener')
-            ->replaceArgument(4, $transaction_naming_service)
+            ->replaceArgument(2, $transaction_naming_service)
         ;
     }
 }

--- a/Listener/RequestListener.php
+++ b/Listener/RequestListener.php
@@ -19,10 +19,6 @@ use Ekino\Bundle\NewRelicBundle\TransactionNamingStrategy\TransactionNamingStrat
 
 class RequestListener
 {
-    protected $ignoreRoutes;
-
-    protected $ignoreUrls;
-
     protected $newRelic;
 
     protected $interactor;
@@ -35,12 +31,10 @@ class RequestListener
      * @param array                       $ignoreRoutes
      * @param array                       $ignoreUrls
      */
-    public function __construct(NewRelic $newRelic, NewRelicInteractorInterface $interactor, array $ignoreRoutes, array $ignoreUrls, TransactionNamingStrategyInterface $transactionNamingStrategy)
+    public function __construct(NewRelic $newRelic, NewRelicInteractorInterface $interactor, TransactionNamingStrategyInterface $transactionNamingStrategy)
     {
         $this->interactor   = $interactor;
         $this->newRelic     = $newRelic;
-        $this->ignoreRoutes = $ignoreRoutes;
-        $this->ignoreUrls   = $ignoreUrls;
         $this->transactionNamingStrategy = $transactionNamingStrategy;
     }
 

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -15,8 +15,6 @@
 
             <argument type="service" id="ekino.new_relic" />
             <argument type="service" id="ekino.new_relic.interactor" />
-            <argument type="collection" />
-            <argument type="collection" />
             <argument />
         </service>
 

--- a/Silex/EkinoNewRelicServiceProvider.php
+++ b/Silex/EkinoNewRelicServiceProvider.php
@@ -70,7 +70,7 @@ class EkinoNewRelicServiceProvider implements ServiceProviderInterface
 
         // Listeners
         $app['new_relic.request_listener'] = $app->share(function ($app) {
-            return new RequestListener($app['new_relic'], $app['new_relic.interactor'], array(), array(), $app['new_relic.transaction_naming_strategy']);
+            return new RequestListener($app['new_relic'], $app['new_relic.interactor'], $app['new_relic.transaction_naming_strategy']);
         });
         $app['new_relic.exception_listener'] = $app->share(function ($app) {
             return new ExceptionListener($app['new_relic.interactor']);

--- a/Tests/Listener/RequestListenerTest.php
+++ b/Tests/Listener/RequestListenerTest.php
@@ -32,7 +32,7 @@ class RequestListenerTest extends \PHPUnit_Framework_TestCase
 
         $event = new GetResponseEvent($kernel, $request, HttpKernelInterface::SUB_REQUEST);
 
-        $listener = new RequestListener(new NewRelic('App name', 'Token'), $interactor, array(), array(), $namingStrategy);
+        $listener = new RequestListener(new NewRelic('App name', 'Token'), $interactor, $namingStrategy);
         $listener->onCoreRequest($event);
     }
 
@@ -48,7 +48,7 @@ class RequestListenerTest extends \PHPUnit_Framework_TestCase
 
         $event = new GetResponseEvent($kernel, $request, HttpKernelInterface::MASTER_REQUEST);
 
-        $listener = new RequestListener(new NewRelic('App name', 'Token'), $interactor, array(), array(), $namingStrategy);
+        $listener = new RequestListener(new NewRelic('App name', 'Token'), $interactor, $namingStrategy);
         $listener->onCoreRequest($event);
     }
 }


### PR DESCRIPTION
They are simply unused. Additionally it looks like that may
be not the right place to define this, because the best they can solve is
to prevent the listener from setting the transaction name, but the
request itself is stilled reported to newrelic.
