### PR TITLE
Changed Symfony deps

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,8 +14,8 @@
     ],
     "require-dev": {
         "silex/silex": "~1.0",
-        "symfony/framework-bundle": "*",
-        "symfony/console": "*"
+        "symfony/framework-bundle": "~2.2",
+        "symfony/console": "~2.2"
     },
     "autoload": {
         "psr-0": { "Ekino\\Bundle\\NewRelicBundle": "" }


### PR DESCRIPTION
Issue #31 brought up the issue that the bundle is only compatible with newer versions of Symfony 2, even though composer.json doesn't reflect this. I investigated this and found that we need Symfony 2.2 or higher and have updated the composer.json to reflect this.
