### PR TITLE
[Bugfix] Wrong transactions reported when using Symfony's HTTP cache and ESI

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -68,6 +68,7 @@ class Configuration implements ConfigurationInterface
                     ->end()
                 ->end()
                 ->scalarNode('transaction_naming_service')->defaultNull()->end()
+                ->scalarNode('using_symfony_cache')->defaultFalse()->end()
             ->end()
         ;
 

--- a/DependencyInjection/EkinoNewRelicExtension.php
+++ b/DependencyInjection/EkinoNewRelicExtension.php
@@ -52,7 +52,8 @@ class EkinoNewRelicExtension extends Extension
         }
 
         $container->getDefinition('ekino.new_relic.response_listener')
-            ->replaceArgument(2, $config['instrument']);
+            ->replaceArgument(2, $config['instrument'])
+            ->replaceArgument(3, $config['using_symfony_cache'])
         ;
 
         if (!$config['log_exceptions'])
@@ -93,6 +94,7 @@ class EkinoNewRelicExtension extends Extension
 
         $container->getDefinition('ekino.new_relic.request_listener')
             ->replaceArgument(4, $transaction_naming_service)
+            ->replaceArgument(5, $config['using_symfony_cache'])
         ;
     }
 }

--- a/Listener/RequestListener.php
+++ b/Listener/RequestListener.php
@@ -30,18 +30,25 @@ class RequestListener
     protected $transactionNamingStrategy;
 
     /**
+     * @var boolean
+     */
+    protected $symfonyCache;
+
+    /**
      * @param NewRelic                    $newRelic
      * @param NewRelicInteractorInterface $interactor
      * @param array                       $ignoreRoutes
      * @param array                       $ignoreUrls
+     * @param boolean                     $symfonyCache
      */
-    public function __construct(NewRelic $newRelic, NewRelicInteractorInterface $interactor, array $ignoreRoutes, array $ignoreUrls, TransactionNamingStrategyInterface $transactionNamingStrategy)
+    public function __construct(NewRelic $newRelic, NewRelicInteractorInterface $interactor, array $ignoreRoutes, array $ignoreUrls, TransactionNamingStrategyInterface $transactionNamingStrategy, $symfonyCache = false)
     {
         $this->interactor   = $interactor;
         $this->newRelic     = $newRelic;
         $this->ignoreRoutes = $ignoreRoutes;
         $this->ignoreUrls   = $ignoreUrls;
         $this->transactionNamingStrategy = $transactionNamingStrategy;
+        $this->symfonyCache      = $symfonyCache;
     }
 
     /**
@@ -56,8 +63,13 @@ class RequestListener
         $transactionName = $this->transactionNamingStrategy->getTransactionName($event->getRequest());
 
         if ($this->newRelic->getName()) {
+            if ($this->symfonyCache) {
+                $this->interactor->startTransaction($this->newRelic->getName());
+            }
+
             $this->interactor->setApplicationName($this->newRelic->getName(), $this->newRelic->getLicenseKey(), $this->newRelic->getXmit());
         }
+
         $this->interactor->setTransactionName($transactionName);
     }
 }

--- a/Listener/ResponseListener.php
+++ b/Listener/ResponseListener.php
@@ -36,17 +36,24 @@ class ResponseListener
     protected $instrument;
 
     /**
+     * @var boolean
+     */
+    protected $symfonyCache;
+
+    /**
      * Constructor
      *
      * @param NewRelic                    $newRelic
      * @param NewRelicInteractorInterface $interactor
      * @param boolean                     $instrument
+     * @param boolean                     $symfonyCache
      */
-    public function __construct(NewRelic $newRelic, NewRelicInteractorInterface $interactor, $instrument = false)
+    public function __construct(NewRelic $newRelic, NewRelicInteractorInterface $interactor, $instrument = false, $symfonyCache = false)
     {
-        $this->newRelic   = $newRelic;
-        $this->interactor = $interactor;
-        $this->instrument = $instrument;
+        $this->newRelic     = $newRelic;
+        $this->interactor   = $interactor;
+        $this->instrument   = $instrument;
+        $this->symfonyCache = $symfonyCache;
     }
 
     /**
@@ -83,6 +90,10 @@ class ResponseListener
                     }
                 }
             }
+        }
+
+        if ($this->symfonyCache) {
+            $this->interactor->endTransaction();
         }
     }
 }

--- a/NewRelic/BlackholeInteractor.php
+++ b/NewRelic/BlackholeInteractor.php
@@ -91,4 +91,18 @@ class BlackholeInteractor implements NewRelicInteractorInterface
     public function disableBackgroundJob()
     {
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function startTransaction($name)
+    {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function endTransaction()
+    {
+    }
 }

--- a/NewRelic/LoggingInteractorDecorator.php
+++ b/NewRelic/LoggingInteractorDecorator.php
@@ -154,4 +154,22 @@ class LoggingInteractorDecorator implements NewRelicInteractorInterface
         $this->log('Disabling New Relic background job');
         $this->interactor->enableBackgroundJob();
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function endTransaction()
+    {
+        $this->log('Ending a New Relic transaction');
+        newrelic_end_transaction(false);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function startTransaction($name)
+    {
+        $this->log(sprintf('Starting a new New Relic transaction for app "%s"', $name));
+        newrelic_start_transaction($name);
+    }
 }

--- a/NewRelic/NewRelic.php
+++ b/NewRelic/NewRelic.php
@@ -28,9 +28,10 @@ class NewRelic
     protected $customParameters;
 
     /**
-     * @param string $name
-     * @param string $apiKey
-     * @param string $licenseKey
+     * @param string  $name
+     * @param string  $apiKey
+     * @param string  $licenseKey
+     * @param boolean $xmit
      */
     public function __construct($name, $apiKey, $licenseKey = null, $xmit = false)
     {

--- a/NewRelic/NewRelicInteractor.php
+++ b/NewRelic/NewRelicInteractor.php
@@ -100,4 +100,20 @@ class NewRelicInteractor implements NewRelicInteractorInterface
     {
         newrelic_background_job(false);
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function endTransaction()
+    {
+        newrelic_end_transaction(false);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function startTransaction($name)
+    {
+        newrelic_start_transaction($name);
+    }
 }

--- a/NewRelic/NewRelicInteractorInterface.php
+++ b/NewRelic/NewRelicInteractorInterface.php
@@ -81,4 +81,20 @@ interface NewRelicInteractorInterface
      * @return void
      */
     function disableBackgroundJob();
+
+    /**
+     * If you previously ended a transaction you many want to start a new one.
+     *
+     * @param string $name app name
+     *
+     * @return void
+     */
+    public function startTransaction($name);
+
+    /**
+     * End a transaction now
+     *
+     * @return void
+     */
+    public function endTransaction();
 }

--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ ekino_new_relic:
     instrument: false                     # If true, uses enhanced New Relic RUM instrumentation (see below)
     log_exceptions: false                 # If true, sends exceptions to New Relic
     log_commands: true                    # If true, logs CLI commands to New Relic as Background jobs (>2.3 only)
+    using_symfony_cache: false            # Symfony HTTP cache (see below)
     transaction_naming: route             # route, controller or service (see below)
     transaction_naming_service: ~         # Transaction naming service (see below)
 ```
@@ -127,6 +128,13 @@ If enhanced RUM instrumentation is enabled, you can *disable* instrumentation fo
 The bundle comes with two built-in transaction naming strategies. ```route``` and ```controller```, naming the New Relic transaction after the route or controller respectively. However, the bundle supports custom transaction naming strategies through the ```service``` configuration option. If you have selected the ```service``` configuration option, you must pass the name of your own transaction naming service as the ```transaction_naming_service``` configuration option.
 
 The transaction naming service class must implement the ```Ekino\Bundle\NewRelicBundle\TransactionNamingStrategy\TransactionNamingStrategyInterface``` interface. For more information on creating your own services, see the Symfony documentation on [Creating/Configuring Services in the Container](http://symfony.com/doc/current/book/service_container.html#creating-configuring-services-in-the-container).
+
+## Symfony HTTP Cache
+
+When you are using Symfony's HTTP cache your `app/AppCache.php` will build up a response with your Edge Side Includes (ESI). This will look like one transaction in New Relic. When you set `using_symfony_cache: true` will these ESI request be separate transaction which improves the statistics. If you are using some other reverse proxy cache or no cache at all, leave this to false.
+
+If true is required to set the `application_name`.
+
 
 ## Deployment notification
 

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -11,12 +11,13 @@
 
     <services>
         <service id="ekino.new_relic.request_listener" class="Ekino\Bundle\NewRelicBundle\Listener\RequestListener">
-            <tag name="kernel.event_listener" event="kernel.request" method="onCoreRequest" priority="-1"/>
+            <tag name="kernel.event_listener" event="kernel.request" method="onCoreRequest" priority="1"/>
 
             <argument type="service" id="ekino.new_relic" />
             <argument type="service" id="ekino.new_relic.interactor" />
             <argument type="collection" />
             <argument type="collection" />
+            <argument />
             <argument />
         </service>
 
@@ -42,11 +43,12 @@
         </service>
 
         <service id="ekino.new_relic.response_listener" class="Ekino\Bundle\NewRelicBundle\Listener\ResponseListener">
-            <tag name="kernel.event_listener" event="kernel.response" method="onCoreResponse" priority="-1"/>
+            <tag name="kernel.event_listener" event="kernel.response" method="onCoreResponse" priority="-255"/>
 
             <argument type="service" id="ekino.new_relic" />
             <argument type="service" id="ekino.new_relic.interactor" />
             <argument>false</argument>
+            <argument />
         </service>
 
         <service id="ekino.new_relic.command_listener" class="Ekino\Bundle\NewRelicBundle\Listener\CommandListener">

--- a/Tests/Listener/RequestListenerTest.php
+++ b/Tests/Listener/RequestListenerTest.php
@@ -41,6 +41,7 @@ class RequestListenerTest extends \PHPUnit_Framework_TestCase
         $interactor = $this->getMock('Ekino\Bundle\NewRelicBundle\NewRelic\NewRelicInteractorInterface');
         $interactor->expects($this->once())->method('setTransactionName');
 
+
         $namingStrategy = $this->getMock('Ekino\Bundle\NewRelicBundle\TransactionNamingStrategy\TransactionNamingStrategyInterface');
 
         $kernel = $this->getMock('Symfony\Component\HttpKernel\HttpKernelInterface');
@@ -49,6 +50,38 @@ class RequestListenerTest extends \PHPUnit_Framework_TestCase
         $event = new GetResponseEvent($kernel, $request, HttpKernelInterface::MASTER_REQUEST);
 
         $listener = new RequestListener(new NewRelic('App name', 'Token'), $interactor, array(), array(), $namingStrategy);
+        $listener->onCoreRequest($event);
+    }
+
+    public function testSymfonyCacheEnabled()
+    {
+        $interactor = $this->getMock('Ekino\Bundle\NewRelicBundle\NewRelic\NewRelicInteractorInterface');
+        $interactor->expects($this->once())->method('startTransaction');
+
+        $namingStrategy = $this->getMock('Ekino\Bundle\NewRelicBundle\TransactionNamingStrategy\TransactionNamingStrategyInterface');
+
+        $kernel = $this->getMock('Symfony\Component\HttpKernel\HttpKernelInterface');
+        $request = new Request();
+
+        $event = new GetResponseEvent($kernel, $request, HttpKernelInterface::MASTER_REQUEST);
+
+        $listener = new RequestListener(new NewRelic('App name', 'Token'), $interactor, array(), array(), $namingStrategy, true);
+        $listener->onCoreRequest($event);
+    }
+
+    public function testSymfonyCacheDisabled()
+    {
+        $interactor = $this->getMock('Ekino\Bundle\NewRelicBundle\NewRelic\NewRelicInteractorInterface');
+        $interactor->expects($this->never())->method('startTransaction');
+
+        $namingStrategy = $this->getMock('Ekino\Bundle\NewRelicBundle\TransactionNamingStrategy\TransactionNamingStrategyInterface');
+
+        $kernel = $this->getMock('Symfony\Component\HttpKernel\HttpKernelInterface');
+        $request = new Request();
+
+        $event = new GetResponseEvent($kernel, $request, HttpKernelInterface::MASTER_REQUEST);
+
+        $listener = new RequestListener(new NewRelic('App name', 'Token'), $interactor, array(), array(), $namingStrategy, false);
         $listener->onCoreRequest($event);
     }
 }

--- a/Tests/Listener/ResponseListenerTest.php
+++ b/Tests/Listener/ResponseListenerTest.php
@@ -60,6 +60,32 @@ class ResponseListenerTest extends \PHPUnit_Framework_TestCase
         $object->onCoreResponse($event);
     }
 
+    public function testSymfonyCacheEnabled()
+    {
+        $this->setupNoCustomMetricsOrParameters();
+
+        $this->interactor->expects($this->once())->method('endTransaction');
+
+        $request = $this->createRequestMock(false);
+        $event = $this->createFilterResponseEventMock($request, null);
+
+        $object = new ResponseListener($this->newRelic, $this->interactor, false, true);
+        $object->onCoreResponse($event);
+    }
+
+    public function testSymfonyCacheDisabled()
+    {
+        $this->setupNoCustomMetricsOrParameters();
+
+        $this->interactor->expects($this->never())->method('endTransaction');
+
+        $request = $this->createRequestMock(false);
+        $event = $this->createFilterResponseEventMock($request, null);
+
+        $object = new ResponseListener($this->newRelic, $this->interactor, false, false);
+        $object->onCoreResponse($event);
+    }
+
     /**
      * @dataProvider providerOnCoreResponseOnlyInstrumentHTMLResponses
      */


### PR DESCRIPTION
I'm using Symfony's HTTP cache and I do not have any other reverse proxy caches (like Varnish) in front of my application. I've noticed that those pages that are using ESI was under represented new relic transactions. In fact, I had more ESI subrequest than main requests. 

I have one request called "startpage" and within that request it calls a subrequest to "mainMenu". The mainMenu request still has _requestType() = HttpKernelInterface::MASTER_REQUEST_... So what happens is that the two requests are merged into one transaction that will be named "mainMenu" (or what ever ESI request that is executed last).

With this PR you may specify that you are using Symfony's HTTP cache and the bundle will be running newrelic_start_transaction() and newrelic_end_transaction() on incoming requests and outgoing responses respectively. Now will the different ESI requests be logged as different transactions. 

I don't want this to be enabled by default because there is some execution time that we are missing. It is the code in the Kernel and the other event listeners that is executed before our RequestListener executes. 
