### PR TITLE
[Bugfix] Backhole should be used when php extension is no loaded

### DIFF
--- a/DependencyInjection/EkinoNewRelicExtension.php
+++ b/DependencyInjection/EkinoNewRelicExtension.php
@@ -36,7 +36,7 @@ class EkinoNewRelicExtension extends Extension
         $loader = new Loader\XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('services.xml');
 
-        $interactor = $config['enabled'] && function_exists('newrelic_name_transaction')
+        $interactor = $config['enabled'] && extension_loaded('newrelic')
             ? 'ekino.new_relic.interactor.real'
             : 'ekino.new_relic.interactor.blackhole';
 

--- a/Silex/EkinoNewRelicServiceProvider.php
+++ b/Silex/EkinoNewRelicServiceProvider.php
@@ -36,7 +36,7 @@ class EkinoNewRelicServiceProvider implements ServiceProviderInterface
 {
     public function register(Application $app)
     {
-        $app['new_relic.enabled'] = function_exists('newrelic_name_transaction');
+        $app['new_relic.enabled'] = extension_loaded('newrelic');
         $app['new_relic.application_name'] = 'Silex Application';
         $app['new_relic.api_key'] = null;
         $app['new_relic.logging'] = false;


### PR DESCRIPTION
I discovered this bug by accident when I somehow had the wrong path to newrelic.so in the newrelic.ini file. 

I got errors like:

``` php
PHP Fatal error:  Call to undefined function Ekino\Bundle\NewRelicBundle\NewRelic\ /
newrelic_set_appname() in /my/user/path/Symfony/vendor/ekino/newrelicbundle /
/Ekino/Bundle/NewRelicBundle/NewRelic/NewRelicInteractor.php on line 21
```

According to the [new relic documentaion](https://docs.newrelic.com/docs/php/the-php-api) you should use _extension_loaded('newrelic')_ to check if the extension is loaded. 

The issue is not present if you do as the docs says. 
