### PR TITLE
notifydeploycommand only added if new_relic's here

### DIFF
--- a/EkinoNewRelicBundle.php
+++ b/EkinoNewRelicBundle.php
@@ -22,8 +22,6 @@ class EkinoNewRelicBundle extends Bundle
      */
     public function registerCommands(Application $application)
     {
-        parent::registerCommands($application);
-
         $container = $application->getKernel()->getContainer();
 
         if ($container->has('ekino.new_relic')) {


### PR DESCRIPTION
registerCommands now adds the notifydeploy command really only  if new_relic is present. parent::registerCommand was always adding it before, that's why I removed it.