### PR TITLE
Make sure we test with multiple symfony versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,12 @@ php:
   # - 5.4
 
 env:
-  - SYMFONY_VERSION=2.0.16
-  - SYMFONY_VERSION=origin/master
+  - SYMFONY_VERSION=2.2.*
+  - SYMFONY_VERSION=2.3.*
+  - SYMFONY_VERSION=2.4.*
+  - SYMFONY_VERSION=dev-master
 
-before_script:
-  - wget -nc http://getcomposer.org/composer.phar
-  - php composer.phar install
+install:
+  - composer require symfony/framework-bundle:${SYMFONY_VERSION}
 
 script: phpunit


### PR DESCRIPTION
It is two fixes in this commit. 
## Fix 1

Make sure we test with multiple versions of Symfony. At the moment we are just checking with the latest version.

This is a run with [SYMFONY_VERSION=2.0.16](https://travis-ci.org/ekino/EkinoNewRelicBundle/jobs/16181133). But as you can see, composer downloads symfony/framework-bundle v2.4.0.

I removed _before_script_ and replaced it with a call to the built-in Composer and I'm making sure we use the SYMFONY_VERSION variable...

Here is the [Travis documentation](http://about.travis-ci.org/docs/user/languages/php/) where you can find examples of using variables.
## Fix 2

In composer.json it is specified that we support Symfony2.2 and later. There is no need of testing Travis with Symfony2.0.16. You should change one or the other, I chosed to change .travis.yml since composer.json seems to be more entertained. 

~~I changed the max version to the latest stable release of Symfony, because that is the max version composer.json lets us use. If we want to check with origin/master we should add _@dev_ on _symfony/framework-bundle_ in the composer file.~~
