### PR TITLE
Allow tests against symfony dev-version to fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ php:
 matrix:
   allow_failures:
     - php: hhvm
+    - env: "SYMFONY_VERSION=dev-master"
 
 env:
   - SYMFONY_VERSION=2.2.*


### PR DESCRIPTION
At least I wouldn't _expect_ a test against an unstable dependencies to succeed, but anyway: _Currently_ it fails.
