### PR TITLE
Use interactor instead of direct newrelic calls

### DIFF
--- a/NewRelic/LoggingInteractorDecorator.php
+++ b/NewRelic/LoggingInteractorDecorator.php
@@ -170,7 +170,7 @@ class LoggingInteractorDecorator implements NewRelicInteractorInterface
     public function endTransaction()
     {
         $this->log('Ending a New Relic transaction');
-        newrelic_end_transaction(false);
+        $this->interactor->endTransaction();
     }
 
     /**
@@ -179,6 +179,6 @@ class LoggingInteractorDecorator implements NewRelicInteractorInterface
     public function startTransaction($name)
     {
         $this->log(sprintf('Starting a new New Relic transaction for app "%s"', $name));
-        newrelic_start_transaction($name);
+        $this->interactor->startTransaction($name);
     }
 }


### PR DESCRIPTION
On the `1.2.1` stable release a new feature was added for watching the symfony cache.  This PR broke the `enabled/disabled` status of the bundle because it calls newrelic php commands directly instead of using the interactor class. 

Consequently, this broke my builds on travis because travis has the black hole interactor, and newrelic is NOT installed.

This fixes the `LoggingInteractorDecorator` to use the interactor the same way all the other calls work.

Once this is merge, is it possible to quickly release a `1.2.2` stable?
