### PR TITLE
notify deployment with roll-up naming

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -26,11 +26,20 @@ class Configuration implements ConfigurationInterface
         $rootNode = $treeBuilder->root('ekino_new_relic');
 
         $rootNode
+            ->fixXmlConfig('deployment_name')
             ->children()
                 ->booleanNode('enabled')->defaultTrue()->end()
                 ->scalarNode('api_key')->defaultValue(false)->end()
                 ->scalarNode('license_key')->defaultValue(null)->end()
                 ->scalarNode('application_name')->defaultValue(null)->end()
+                ->arrayNode('deployment_names')
+                    ->prototype('scalar')
+                    ->end()
+                    ->beforeNormalization()
+                        ->ifTrue(function ($v) { return !is_array($v); })
+                        ->then(function ($v) { return array_values(array_filter(explode(';', $v))); })
+                    ->end()
+                ->end()
                 ->scalarNode('xmit')->defaultValue(false)->end()
                 ->scalarNode('logging')
                     ->defaultFalse()

--- a/DependencyInjection/EkinoNewRelicExtension.php
+++ b/DependencyInjection/EkinoNewRelicExtension.php
@@ -73,11 +73,16 @@ class EkinoNewRelicExtension extends Extension
             $container->removeDefinition('ekino.new_relic.command_listener');
         }
 
+        if (!$config['deployment_names']) {
+            $config['deployment_names'] = array_values(array_filter(explode(';', $config['application_name'])));
+        }
+
         $container->getDefinition('ekino.new_relic')
             ->replaceArgument(0, $config['application_name'])
             ->replaceArgument(1, $config['api_key'])
             ->replaceArgument(2, $config['license_key'])
             ->replaceArgument(3, $config['xmit'])
+            ->replaceArgument(4, $config['deployment_names'])
         ;
 
         switch ($config['transaction_naming'])

--- a/NewRelic/NewRelic.php
+++ b/NewRelic/NewRelic.php
@@ -27,18 +27,22 @@ class NewRelic
 
     protected $customParameters;
 
+    protected $deploymentNames;
+
     /**
      * @param string  $name
      * @param string  $apiKey
      * @param string  $licenseKey
      * @param boolean $xmit
+     * @param array   $deploymentNames
      */
-    public function __construct($name, $apiKey, $licenseKey = null, $xmit = false)
+    public function __construct($name, $apiKey, $licenseKey = null, $xmit = false, array $deploymentNames = array())
     {
         $this->name             = $name ?: ini_get('newrelic.appname');
         $this->apiKey           = $apiKey;
         $this->licenseKey       = $licenseKey ?: ini_get('newrelic.license');
         $this->xmit             = $xmit;
+        $this->deploymentNames  = $deploymentNames;
         $this->customMetrics    = array();
         $this->customParameters = array();
     }
@@ -119,6 +123,14 @@ class NewRelic
     public function getName()
     {
         return $this->name;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getDeploymentNames()
+    {
+        return $this->deploymentNames;
     }
 
     /**

--- a/README.md
+++ b/README.md
@@ -11,12 +11,12 @@ This bundle integrates the NewRelic PHP API into Symfony2. For more information 
 
 3. **Exception Listening**: It also captures all Symfony2 exceptions in web requests and console commands and sends them to New Relic (something new relic doesn't do too well itself as symfony2 aggressively catches all exceptions/errors). It also ensures all HTTP Exceptions (4xx codes) are logged as notices in New Relic and not exceptions to reduce the noise in New Relic.
 
-4. **Interactor Service**: It provides you the New Relic PHP Agent API via a Service class `ekino.newrelic.interactor` so in my code, I can inject it into any class, controller, service and do stuff like - 
+4. **Interactor Service**: It provides you the New Relic PHP Agent API via a Service class `ekino.newrelic.interactor` so in my code, I can inject it into any class, controller, service and do stuff like -
 
     ```php
     // Bundle
     $this->newRelic->addCustomParameter('name', 'john');
-    
+
     // Extension
     if (extension_loaded('newrelic')) {
         \newrelic_add_custom_parameter('name', 'john');
@@ -120,12 +120,14 @@ $bundles = array(
 
 ### Step 3 : Configure the bundle
 
-``` yaml
+```yaml
 # app/config/config.yml
 
 ekino_new_relic:
     enabled: true                         # Defaults to true
-    application_name: Awesome Application # Application name (optional, default value is read from php.ini)
+    application_name: Awesome Application # default value in newrelic is "PHP Application", or whatever is set
+                                          # as php ini-value
+    deployment_names: ~                   # default value is 'application_name', supports string array or semi-colon separated string
     api_key:                              # New Relic API
     license_key:                          # New Relic license key (optional, default value is read from php.ini)
     xmit: false                           # if you want to record the metric data up to the point newrelic_set_appname is called, set this to true
@@ -182,6 +184,8 @@ Options:
 
 The bundle provide a [Capifony](http://capifony.org) recipe to automate the deployment notifications (see `Resources/recipes/newrelic.rb`).
 
+It makes one request per `app_name`, due roll-up names are not supported by Data REST API.
+
 ## Integration with SonataBlockBundle
 
 ### Step 0: Install SonataBlockBundle
@@ -190,7 +194,7 @@ Review [SonataBlockBundle](http://sonata-project.org/bundles/block/master/doc/re
 
 ### Step 1: Enable your block:
 
-``` yaml
+```yaml
 # app/config/config.yml
 
 sonata_block:
@@ -211,7 +215,7 @@ Review [SonataAdminBundle](http://sonata-project.org/bundles/admin/master/doc/in
 
 ### Step 1: Enable your block:
 
-``` yaml
+```yaml
 # app/config/config.yml
 sonata_block:
     blocks:

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -42,6 +42,7 @@
             <argument />
             <argument />
             <argument />
+            <argument type="collection" />
         </service>
 
         <service id="ekino.new_relic.response_listener" class="Ekino\Bundle\NewRelicBundle\Listener\ResponseListener">

--- a/Resources/recipes/newrelic.rb
+++ b/Resources/recipes/newrelic.rb
@@ -31,7 +31,7 @@ namespace :newrelic do
       logger.debug "Uploading deployment to New Relic"
       capifony_pretty_print "--> Notifying New Relic of deployment"
 
-      run "cd #{latest_release} && #{php_bin} #{symfony_console} newrelic:notify-deployment --env=#{symfony_env_prod} --no-debug --revision=#{rev.shellescape} --changelog=#{changelog.to_s.shellescape} --description=#{description.to_s.shellescape} --user=#{user.to_s.shellescape}"
+      run "cd #{latest_release} && #{php_bin} #{symfony_console} newrelic:notify-deployment #{console_options} --revision=#{rev.shellescape} --changelog=#{changelog.to_s.shellescape} --description=#{description.to_s.shellescape} --user=#{user.to_s.shellescape}"
       capifony_puts_ok
     rescue Capistrano::CommandError
       logger.info "Unable to notify New Relic of the deployment... skipping"

--- a/Tests/DependencyInjection/ConfigurationTest.php
+++ b/Tests/DependencyInjection/ConfigurationTest.php
@@ -80,6 +80,8 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
         $this->assertInternalType('array', $config['ignored_paths']);
         $this->assertEmpty($config['ignored_commands']);
         $this->assertInternalType('array', $config['ignored_commands']);
+        $this->assertEmpty($config['deployment_names']);
+        $this->assertInternalType('array', $config['deployment_names']);
     }
 
     public static function ignoredRoutesProvider ()
@@ -107,6 +109,29 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
             array(array('single:ignored:command'), array('single:ignored:command')),
             array(array('ignored:command1', 'ignored:command2'), array('ignored:command1', 'ignored:command2'))
         );
+    }
+
+    public static function deploymentNamesProvider()
+    {
+        return array(
+            array('App1', array('App1')),
+            array(array('App1'), array('App1')),
+            array(array('App1', 'App2'), array('App1', 'App2')),
+        );
+    }
+
+    /**
+     * @dataProvider deploymentNamesProvider
+     */
+    public function testDeploymentNames($deploymentNameConfig, $expected)
+    {
+        $processor = new Processor();
+
+        $config1 = $processor->processConfiguration(new Configuration(), array('ekino_new_relic' => array('deployment_name' => $deploymentNameConfig)));
+        $config2 = $processor->processConfiguration(new Configuration(), array('ekino_new_relic' => array('deployment_names' => $deploymentNameConfig)));
+
+        $this->assertEquals($expected, $config1['deployment_names']);
+        $this->assertEquals($expected, $config2['deployment_names']);
     }
 
     /**


### PR DESCRIPTION
Got HTTP 422 while "notify deployment" if using roll-up naming strategy, eg. "MyApp1;MyApp".

>The answer from New Relic support:

>The naming technique where you separate the two 'application' names with a semicolon is a technique that is used by the agent in it's configuration files or api calls. It does not carry over into the Data Rest API, however. If you want the deployment to be inserted for both applications it will be necessary to execute two curl commands, one for each application. This can not be done is a single command.

Its totally transparent for single naming strategy.
If `deployment_name` or `deployment_names` is not set, then `application_name` is a candidate for names split.