### PR TITLE
ControllerNamingStrategy crashes on cb controllers

### DIFF
--- a/Tests/TransactionNamingStrategy/ControllerNamingStrategyTest.php
+++ b/Tests/TransactionNamingStrategy/ControllerNamingStrategyTest.php
@@ -1,0 +1,53 @@
+<?php
+
+/*
+ * This file is part of Ekino New Relic bundle.
+ *
+ * (c) Ekino - Thomas Rabaix <thomas.rabaix@ekino.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Ekino\Bundle\NewRelicBundle\TransactionNamingStrategy;
+
+use Symfony\Component\HttpFoundation\Request;
+
+class ControllerNamingStrategyTest extends \PHPUnit_Framework_TestCase
+{
+    public function testControllerAsString()
+    {
+        $request = new Request();
+        $request->attributes->set('_controller', 'SomeBundle:Some:SomeAction');
+
+        $strategy = new ControllerNamingStrategy();
+        $this->assertEquals('SomeBundle:Some:SomeAction', $strategy->getTransactionName($request));
+    }
+
+    public function testControllerAsClosure()
+    {
+        $request = new Request();
+        $request->attributes->set('_controller', function () {
+        });
+
+        $strategy = new ControllerNamingStrategy();
+        $this->assertEquals('Closure controller', $strategy->getTransactionName($request));
+    }
+
+    public function testControllerAsCallback()
+    {
+        $request = new Request();
+        $request->attributes->set('_controller', array($this, 'testControllerAsString'));
+
+        $strategy = new ControllerNamingStrategy();
+        $this->assertEquals('Callback contoller: Ekino\Bundle\NewRelicBundle\TransactionNamingStrategy\ControllerNamingStrategyTest::testControllerAsString()', $strategy->getTransactionName($request));
+    }
+
+    public function testControllerUnknown()
+    {
+        $request = new Request();
+
+        $strategy = new ControllerNamingStrategy();
+        $this->assertEquals('Unknown Symfony controller', $strategy->getTransactionName($request));
+    }
+}


### PR DESCRIPTION
If the controller is a callback rather than a reference to some class method, the bundle crashes trying to convert a closure to a string, e.g.:

```php
$request->attributes->set('_controller', function() {
  return new Response('lol');
});
```

Additionally, i made the code look for the _attribute_ `_controller`, rather than either a get parameter, post parameter, etc called `_controller`