### PR TITLE
Increment response listener priority in order to avoid New Relic transactions with false application name

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ before_install:
   - composer self-update    
 
 install:
-  - composer require symfony/framework-bundle:${SYMFONY_VERSION} --prefer-source
+  - composer require symfony/framework-bundle:${SYMFONY_VERSION} symfony/security-bundle:${SYMFONY_VERSION} symfony/twig-bundle:${SYMFONY_VERSION} --prefer-source
 
 script:
   - make test

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -13,7 +13,12 @@
 
     <services>
         <service id="ekino.new_relic.request_listener" class="Ekino\Bundle\NewRelicBundle\Listener\RequestListener">
-            <tag name="kernel.event_listener" event="kernel.request" method="onCoreRequest" priority="1"/>
+            <!--
+                Priority set to 31 because it should be lower than 32 RouterListener::onKernelRequest and greater
+                than 8 Firewall::onKernelRequest. Otherwise the transactions will not be tracked on the right
+                New Relic application or the route name will not be still available
+            -->
+            <tag name="kernel.event_listener" event="kernel.request" method="onCoreRequest" priority="31"/>
 
             <argument type="service" id="ekino.new_relic" />
             <argument type="service" id="ekino.new_relic.interactor" />

--- a/Tests/Functional/Bundle/AppBundle/AppBundle.php
+++ b/Tests/Functional/Bundle/AppBundle/AppBundle.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Ekino\Bundle\NewRelicBundle\Tests\Functional\Bundle\AppBundle;
+
+use Symfony\Component\HttpKernel\Bundle\Bundle;
+
+class AppBundle extends Bundle
+{
+}

--- a/Tests/Functional/Bundle/AppBundle/Controller/FooController.php
+++ b/Tests/Functional/Bundle/AppBundle/Controller/FooController.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Ekino\Bundle\NewRelicBundle\Tests\Functional\Bundle\AppBundle\Controller;
+
+use Symfony\Component\DependencyInjection\ContainerAware;
+use Symfony\Component\HttpFoundation\Response;
+
+class FooController extends ContainerAware
+{
+    public function fooAction()
+    {
+        return new Response();
+    }
+}

--- a/Tests/Functional/RequestListenerTest.php
+++ b/Tests/Functional/RequestListenerTest.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace Ekino\Bundle\NewRelicBundle\Tests\Functional;
+
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Ekino\Bundle\NewRelicBundle\Tests\Functional\app\AppKernel;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+class RequestListenerTest extends WebTestCase
+{
+    const EVENT_LISTENER_CLASS = 'Ekino\Bundle\NewRelicBundle\Listener\RequestListener';
+
+    const EVENT_LISTENER_METHOD = 'onCoreRequest';
+
+    const EVENT_LISTENER_PRIORITY = 31;
+
+    /**
+     * Tests that the request listener is called for a given request url
+     *
+     * @dataProvider urlProvider
+     */
+    public function testIsCalled($url)
+    {
+        $kernel = self::createKernel();
+        $kernel->boot();
+
+        // Remove new relic listener
+        $dispatcher = $kernel->getContainer()->get('event_dispatcher');
+        $listener = $this->findNewRelicRequestListener($dispatcher);
+        $dispatcher->removeListener(KernelEvents::REQUEST, $listener);
+
+        // Create mock of new relic kernel.request listener
+        $listener = $this->getMockBuilder($this::EVENT_LISTENER_CLASS)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        // Assert that the NewRelic request listener is called
+        $listener
+            ->expects($this->atLeastOnce())
+            ->method($this::EVENT_LISTENER_METHOD);
+
+        // Add new relic mock listener
+        $dispatcher->addListener(
+            KernelEvents::REQUEST,
+            array($listener, $this::EVENT_LISTENER_METHOD),
+            $this::EVENT_LISTENER_PRIORITY
+        );
+
+        $request = Request::create($url);
+        $kernel->handle($request);
+    }
+
+    public function urlProvider()
+    {
+        return array(
+            array('/no-authentication'),
+            array('/authentication'),
+        );
+    }
+
+    protected static function createKernel(array $options = array())
+    {
+        return new AppKernel(
+            isset($options['config']) ? $options['config'] : 'config_test.yml'
+        );
+    }
+
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $fs = new Filesystem();
+        $fs->remove(sys_get_temp_dir().'/EkinoNewRelicBundle');
+    }
+
+    protected function tearDown()
+    {
+        parent::tearDown();
+
+        $fs = new Filesystem();
+        $fs->remove(sys_get_temp_dir().'/EkinoNewRelicBundle');
+    }
+
+    /**
+     * @param EventDispatcherInterface $dispatcher
+     *
+     * @return callable
+     */
+    private function findNewRelicRequestListener(EventDispatcherInterface $dispatcher)
+    {
+        $listeners = $dispatcher->getListeners(KernelEvents::REQUEST);
+
+        foreach ($listeners as $listener) {
+            if (!is_array($listener)) {
+                return;
+            }
+
+            $class = $listener[0];
+            $method = $listener[1];
+
+            if (get_class($class) === $this::EVENT_LISTENER_CLASS && $method === $this::EVENT_LISTENER_METHOD) {
+                return $listener;
+            }
+        }
+    }
+}

--- a/Tests/Functional/app/AppKernel.php
+++ b/Tests/Functional/app/AppKernel.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Ekino\Bundle\NewRelicBundle\Tests\Functional\app;
+
+use Symfony\Component\Config\Loader\LoaderInterface;
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\HttpKernel\Kernel;
+
+/**
+ * App Test Kernel for functional tests.
+ */
+class AppKernel extends Kernel
+{
+    private $config;
+
+    public function __construct($config)
+    {
+        parent::__construct('test', true);
+
+        $fs = new Filesystem();
+        if (!$fs->isAbsolutePath($config)) {
+            $config = __DIR__.'/config/'.$config;
+        }
+
+        if (!file_exists($config)) {
+            throw new \RuntimeException(sprintf('The config file "%s" does not exist.', $config));
+        }
+
+        $this->config = $config;
+    }
+
+    public function registerBundles()
+    {
+        return array(
+            new \Symfony\Bundle\FrameworkBundle\FrameworkBundle(),
+            new \Symfony\Bundle\SecurityBundle\SecurityBundle(),
+            new \Ekino\Bundle\NewRelicBundle\EkinoNewRelicBundle(),
+            new \Ekino\Bundle\NewRelicBundle\Tests\Functional\Bundle\AppBundle\AppBundle(),
+            new \Symfony\Bundle\TwigBundle\TwigBundle(),
+        );
+    }
+
+    public function registerContainerConfiguration(LoaderInterface $loader)
+    {
+        $loader->load($this->config);
+    }
+
+    public function getCacheDir()
+    {
+        return sys_get_temp_dir().'/EkinoNewRelicBundle/cache/'.sha1($this->config);
+    }
+
+    public function getLogDir()
+    {
+        return sys_get_temp_dir().'/EkinoNewRelicBundle/logs';
+    }
+
+    protected function getContainerClass()
+    {
+        return parent::getContainerClass().sha1($this->config);
+    }
+
+    public function serialize()
+    {
+        return $this->config;
+    }
+
+    public function unserialize($str)
+    {
+        call_user_func_array(array($this, '__construct'), unserialize($str));
+    }
+}

--- a/Tests/Functional/app/Resources/views/base.html.twig
+++ b/Tests/Functional/app/Resources/views/base.html.twig
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="UTF-8" />
+        <title>{% block title %}Welcome!{% endblock %}</title>
+        {% block stylesheets %}{% endblock %}
+        <link rel="shortcut icon" href="{{ asset('favicon.ico') }}" />
+    </head>
+    <body>
+        {% block body %}{% endblock %}
+        {% block javascripts %}{% endblock %}
+    </body>
+</html>

--- a/Tests/Functional/app/config/config_test.yml
+++ b/Tests/Functional/app/config/config_test.yml
@@ -1,0 +1,3 @@
+imports:
+    - { resource: framework.yml }
+    - { resource: security.yml }

--- a/Tests/Functional/app/config/framework.yml
+++ b/Tests/Functional/app/config/framework.yml
@@ -1,0 +1,8 @@
+framework:
+    secret: test
+    session:
+        storage_id: session.storage.filesystem
+    router:
+        resource: "%kernel.root_dir%/config/routing.yml"
+    templating:
+        engines: ['twig']

--- a/Tests/Functional/app/config/routing.yml
+++ b/Tests/Functional/app/config/routing.yml
@@ -1,0 +1,6 @@
+no_authentication:
+    path:     /no-authentication
+    defaults: { _controller: AppBundle:Foo:foo }
+
+authentication:
+    path:     /authentication

--- a/Tests/Functional/app/config/security.yml
+++ b/Tests/Functional/app/config/security.yml
@@ -1,0 +1,22 @@
+security:
+    providers:
+        in_memory:
+            memory:
+                users:
+                    toni: { password: test, roles: [ROLE_FOO] }
+
+    role_hierarchy:
+        ROLE_FOO: [ROLE_BAR]
+
+    encoders:
+        Symfony\Component\Security\Core\User\UserInterface: plaintext
+
+    firewalls:
+        secured_area:
+            pattern:   ^/
+            anonymous: ~
+            form_login: ~
+
+    access_control:
+        - { path: ^/authentication,    roles: ROLE_FOO }
+        - { path: ^/no-authentication, roles: IS_AUTHENTICATED_ANONYMOUSLY }

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,8 @@
         "silex/silex": "~1.0",
         "symfony/framework-bundle": "~2.2",
         "symfony/console": "~2.2",
-        "twig/twig": "1.*"
+        "symfony/security-bundle": "~2.2",
+        "symfony/twig-bundle": "~2.2"
     },
     "suggest": {
         "sonata-project/block-bundle": "2.2.*@dev"

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -11,6 +11,10 @@
          syntaxCheck="false"
          bootstrap="Tests/bootstrap.php"
 >
+    <php>
+        <server name="KERNEL_DIR" value="./Tests/Functional/app" />
+    </php>
+
     <testsuites>
         <testsuite name="Ekino New Relic Test Suite">
             <directory>./Tests</directory>


### PR DESCRIPTION
This pull request is a bug fix. 

The priority of the request listener should be increased to be executed just after  the `Symfony\Component\HttpKernel\EventListener\RouterListener::onKernelRequest`, otherwise all the Symfony application request won't be assigned to the right application name in NewRelic.

In order to reproduce the problem, it is easier if you use the standard Symfony authentication system and call  the `logout` route of Symfony. You will see how the NewRelic transaction will not be asigned to you application name defined in the bundle configuration.
