### PR TITLE
Changed the event priorities

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,11 +186,11 @@ The bundle provide a [Capifony](http://capifony.org) recipe to automate the depl
 
 It makes one request per `app_name`, due roll-up names are not supported by Data REST API.
 
-## The flow of the Request
+## Flow of the Request
 
-1. A request comes in and the first thing we do is to `setApplicaitonName` so that we use the correct license key and name.
+1. A request comes in and the first thing we do is to `setApplicationName` so that we use the correct license key and name.
 2. The `RouterListener` might throw a 404 or add routing values to the request.
-3. If no 404 was thrown we `setIgnoreTransaction` which means that we call `$this->interactor->ignoreTransaction();` if we have configured to ignore the route.
+3. If no 404 was thrown we `setIgnoreTransaction` which means that we call `NewRelicInteractorInterface::ignoreTransaction()` if we have configured to ignore the route.
 4. The Firewall is the next interesting thing that will happen. It could change the controller or throw a 403.
 5. The developer might have configured many more request listeners that will now execute and possibly add stuff to the request.
 6. We will execute `setTransactionName` to use our `TransactionNamingStrategyInterface` to set a nice name. 

--- a/README.md
+++ b/README.md
@@ -186,6 +186,20 @@ The bundle provide a [Capifony](http://capifony.org) recipe to automate the depl
 
 It makes one request per `app_name`, due roll-up names are not supported by Data REST API.
 
+## The flow of the Request
+
+1. A request comes in and the first thing we do is to `setApplicaitonName` so that we use the correct license key and name.
+2. The `RouterListener` might throw a 404 or add routing values to the request.
+3. If no 404 was thrown we `setIgnoreTransaction` which means that we call `$this->interactor->ignoreTransaction();` if we have configured to ignore the route.
+4. The Firewall is the next interesting thing that will happen. It could change the controller or throw a 403.
+5. The developer might have configured many more request listeners that will now execute and possibly add stuff to the request.
+6. We will execute `setTransactionName` to use our `TransactionNamingStrategyInterface` to set a nice name. 
+
+All 6 steps will be executed for a normal request. Exceptions to this is 404 and 403 responses that will be created in 
+step 2 and step 4 respectively. If an exception to these step occurs (I'm not talking about `\Exception`) you will have 
+the transaction logged with the correct license key but you do not have the proper transaction name. The `setTransactionName` may
+have dependencies on data set by other listeners that is why it has such low priority. 
+
 ## Integration with SonataBlockBundle
 
 ### Step 0: Install SonataBlockBundle

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -13,7 +13,8 @@
 
     <services>
         <service id="ekino.new_relic.request_listener" class="Ekino\Bundle\NewRelicBundle\Listener\RequestListener">
-            <tag name="kernel.event_listener" event="kernel.request" method="onCoreRequest" priority="1"/>
+            <tag name="kernel.event_listener" event="kernel.request" method="onCoreRequest" priority="31"/>
+            <tag name="kernel.event_listener" event="kernel.request" method="setTransactionName" priority="-10"/>
 
             <argument type="service" id="ekino.new_relic" />
             <argument type="service" id="ekino.new_relic.interactor" />

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -13,7 +13,8 @@
 
     <services>
         <service id="ekino.new_relic.request_listener" class="Ekino\Bundle\NewRelicBundle\Listener\RequestListener">
-            <tag name="kernel.event_listener" event="kernel.request" method="onCoreRequest" priority="31"/>
+            <tag name="kernel.event_listener" event="kernel.request" method="setApplicationName" priority="255"/>
+            <tag name="kernel.event_listener" event="kernel.request" method="setIgnoreTransaction" priority="31"/>
             <tag name="kernel.event_listener" event="kernel.request" method="setTransactionName" priority="-10"/>
 
             <argument type="service" id="ekino.new_relic" />

--- a/Silex/EkinoNewRelicServiceProvider.php
+++ b/Silex/EkinoNewRelicServiceProvider.php
@@ -95,6 +95,7 @@ class EkinoNewRelicServiceProvider implements ServiceProviderInterface
         }
 
         $app['dispatcher']->addListener(KernelEvents::REQUEST, array($app['new_relic.request_listener'], 'onCoreRequest'), -1);
+        $app['dispatcher']->addListener(KernelEvents::REQUEST, array($app['new_relic.request_listener'], 'setTransactionName'), -1);
 
         $app['dispatcher']->addListener(KernelEvents::RESPONSE, array($app['new_relic.response_listener'], 'onCoreResponse'), -1);
 

--- a/Silex/EkinoNewRelicServiceProvider.php
+++ b/Silex/EkinoNewRelicServiceProvider.php
@@ -94,7 +94,8 @@ class EkinoNewRelicServiceProvider implements ServiceProviderInterface
             return;
         }
 
-        $app['dispatcher']->addListener(KernelEvents::REQUEST, array($app['new_relic.request_listener'], 'onCoreRequest'), -1);
+        $app['dispatcher']->addListener(KernelEvents::REQUEST, array($app['new_relic.request_listener'], 'setApplicationName'), -1);
+        $app['dispatcher']->addListener(KernelEvents::REQUEST, array($app['new_relic.request_listener'], 'setIgnoreTransaction'), -1);
         $app['dispatcher']->addListener(KernelEvents::REQUEST, array($app['new_relic.request_listener'], 'setTransactionName'), -1);
 
         $app['dispatcher']->addListener(KernelEvents::RESPONSE, array($app['new_relic.response_listener'], 'onCoreResponse'), -1);

--- a/Tests/Listener/RequestListenerTest.php
+++ b/Tests/Listener/RequestListenerTest.php
@@ -33,7 +33,7 @@ class RequestListenerTest extends \PHPUnit_Framework_TestCase
         $event = new GetResponseEvent($kernel, $request, HttpKernelInterface::SUB_REQUEST);
 
         $listener = new RequestListener(new NewRelic('App name', 'Token'), $interactor, array(), array(), $namingStrategy);
-        $listener->onCoreRequest($event);
+        $listener->setApplicationName($event);
     }
 
     public function testMasterRequest()
@@ -50,7 +50,6 @@ class RequestListenerTest extends \PHPUnit_Framework_TestCase
         $event = new GetResponseEvent($kernel, $request, HttpKernelInterface::MASTER_REQUEST);
 
         $listener = new RequestListener(new NewRelic('App name', 'Token'), $interactor, array(), array(), $namingStrategy);
-        $listener->onCoreRequest($event);
         $listener->setTransactionName($event);
     }
 
@@ -68,7 +67,7 @@ class RequestListenerTest extends \PHPUnit_Framework_TestCase
         $event = new GetResponseEvent($kernel, $request, HttpKernelInterface::MASTER_REQUEST);
 
         $listener = new RequestListener(new NewRelic('App name', 'Token'), $interactor, array(), array('/ignored_path'), $namingStrategy);
-        $listener->onCoreRequest($event);
+        $listener->setIgnoreTransaction($event);
     }
 
     public function testRouteIsIgnored ()
@@ -85,7 +84,7 @@ class RequestListenerTest extends \PHPUnit_Framework_TestCase
         $event = new GetResponseEvent($kernel, $request, HttpKernelInterface::MASTER_REQUEST);
 
         $listener = new RequestListener(new NewRelic('App name', 'Token'), $interactor, array('ignored_route'), array(), $namingStrategy);
-        $listener->onCoreRequest($event);
+        $listener->setIgnoreTransaction($event);
     }
 
     public function testSymfonyCacheEnabled()
@@ -101,7 +100,7 @@ class RequestListenerTest extends \PHPUnit_Framework_TestCase
         $event = new GetResponseEvent($kernel, $request, HttpKernelInterface::MASTER_REQUEST);
 
         $listener = new RequestListener(new NewRelic('App name', 'Token'), $interactor, array(), array(), $namingStrategy, true);
-        $listener->onCoreRequest($event);
+        $listener->setApplicationName($event);
     }
 
     public function testSymfonyCacheDisabled()
@@ -117,6 +116,6 @@ class RequestListenerTest extends \PHPUnit_Framework_TestCase
         $event = new GetResponseEvent($kernel, $request, HttpKernelInterface::MASTER_REQUEST);
 
         $listener = new RequestListener(new NewRelic('App name', 'Token'), $interactor, array(), array(), $namingStrategy, false);
-        $listener->onCoreRequest($event);
+        $listener->setApplicationName($event);
     }
 }

--- a/Tests/Listener/RequestListenerTest.php
+++ b/Tests/Listener/RequestListenerTest.php
@@ -51,6 +51,7 @@ class RequestListenerTest extends \PHPUnit_Framework_TestCase
 
         $listener = new RequestListener(new NewRelic('App name', 'Token'), $interactor, array(), array(), $namingStrategy);
         $listener->onCoreRequest($event);
+        $listener->setTransactionName($event);
     }
 
     public function testPathIsIgnored ()


### PR DESCRIPTION
This is the registered events in standard symfony.


Listener Class Name | Priority
---------------------------- | ---------
ProfilerListener | 1024
TestSessionListener | 192
SessionListener | 128
RouterListener | 32
LocaleListener | 16
Firewall | 8

([source](http://symfony.com/doc/current/reference/dic_tags.html#kernel-request))

Current behavior is to set the application and transaction name after the firewall. This will lead to that transactions interrupted by the firewall are not getting the proper application key. They will be registered with the license key defined in php.ini. (See #87)

This PR splits the `RequestListener::onCoreRequest` into three functions. One that names the application, one that ignores the transaction and one that names the transaction. The one that set the application name should have as high priority as possible (255 is a nice number) because some listeners might stop the event propagation and return a response. 

Since we want to ignore some routes we should call the `RequestListener::setIgnoreTransaction` as soon as the RouterListener has executed. That's why we should use priority 31.

For the transaction name: If we have too high priority here we might not have sufficient data for the `TransactionNamingStrategyInterface`. If we have to too low, say after the firewall, some transaction will slip through with no name. IMHO, we should make sure we have all data possible. When an exception happens in one of the listeners is it okey not to have a proper name.

This PR will solve issue #87.

Update 2015-05-15 14:17: I've rewrote the description because of the changes that @Lumbendil suggested. 