### PR TITLE
Call newrelic_set_appname() only if different from ini configuration

### DIFF
--- a/Listener/RequestListener.php
+++ b/Listener/RequestListener.php
@@ -64,12 +64,17 @@ class RequestListener
             return;
         }
 
-        if ($this->newRelic->getName()) {
+        $appName = $this->newRelic->getName();
+
+        if ($appName) {
             if ($this->symfonyCache) {
-                $this->interactor->startTransaction($this->newRelic->getName());
+                $this->interactor->startTransaction($appName);
             }
 
-            $this->interactor->setApplicationName($this->newRelic->getName(), $this->newRelic->getLicenseKey(), $this->newRelic->getXmit());
+            // Set application name if different from ini configuration
+            if ($appName !== ini_get('newrelic.appname')) {
+                $this->interactor->setApplicationName($appName, $this->newRelic->getLicenseKey(), $this->newRelic->getXmit());
+            }
         }
     }
 


### PR DESCRIPTION
Calling `newrelic_set_appname()` seems to lose current transaction.

Since `Newrelic::$name` is always filled with the ini settings (#88) then there is no way to avoid the `newrelic_set_appname()` call.

But because the method call is quite late in the php process, then Newrelic decrease the "Time spent in PHP" (and increase the "Request queueing time"), which is wrong. A similar problem was described 2y ago in #24

A solution is not to call the method before but to **not call it at all** if the name doesn't differ from the ini config (and let the extension do its job). I'm not sure this is the right thing to do but at least it works for us. I've only covered the `RequestListener` part.