### PR TITLE
Symfony 2.8 & 3.0 Support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ env:
 matrix:
   include:
     - php: 5.3.3
-      env: SYMFONY_VERSION=2.3.* COMPOSER_FLAGS="--prefer-source"
+      env: SYMFONY_VERSION=2.3.* COMPOSER_FLAGS="--prefer-lowest"
     - php: 5.6
       env: SYMFONY_VERSION=2.3.* COMPOSER_FLAGS="--prefer-source"
     - php: 5.6
@@ -32,7 +32,9 @@ before_install:
   - if [ "$SYMFONY_VERSION" = "2.8.*@dev" ] || [ "$SYMFONY_VERSION" = "3.0.*@dev" ]; then perl -pi -e 's/^}$/,"minimum-stability":"dev"}/' composer.json; fi;
 
 install:
-  - composer require symfony/framework-bundle:${SYMFONY_VERSION} $COMPOSER_FLAGS
+  - composer require symfony/framework-bundle:${SYMFONY_VERSION} --no-update
+  - composer require symfony/console:${SYMFONY_VERSION} --no-update
+  - composer update $COMPOSER_FLAGS
 
 script:
   - make test

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,30 +8,31 @@ php:
   - nightly
 
 env:
-  - SYMFONY_VERSION=2.7.*
+  - SYMFONY_VERSION=2.7.* COMPOSER_FLAGS="--prefer-source"
 
 matrix:
   include:
     - php: 5.3.3
-      env: SYMFONY_VERSION=2.3.* COMPOSER_FLAGS="--prefer-lowest"
+      env: SYMFONY_VERSION=2.3.* COMPOSER_FLAGS="--prefer-source"
     - php: 5.6
-      env: SYMFONY_VERSION=2.3.*
+      env: SYMFONY_VERSION=2.3.* COMPOSER_FLAGS="--prefer-source"
     - php: 5.6
-      env: SYMFONY_VERSION=2.6.*
+      env: SYMFONY_VERSION=2.6.* COMPOSER_FLAGS="--prefer-source"
     - php: 5.6
-      env: SYMFONY_VERSION=2.8.*@dev
+      env: SYMFONY_VERSION=2.8.*@dev COMPOSER_FLAGS=""
     - php: 5.6
-      env: SYMFONY_VERSION=3.0.*@dev
+      env: SYMFONY_VERSION=3.0.*@dev COMPOSER_FLAGS=""
   allow_failures:
-    - env: SYMFONY_VERSION=2.8.*@dev
-    - env: SYMFONY_VERSION=3.0.*@dev
+    - env: SYMFONY_VERSION=2.8.*@dev COMPOSER_FLAGS=""
+    - env: SYMFONY_VERSION=3.0.*@dev COMPOSER_FLAGS=""
     - php: nightly
 
 before_install:
   - composer self-update
+  - if [ "$SYMFONY_VERSION" = "2.8.*@dev" ] || [ "$SYMFONY_VERSION" = "3.0.*@dev" ]; then perl -pi -e 's/^}$/,"minimum-stability":"dev"}/' composer.json; fi;
 
 install:
-  - composer require symfony/framework-bundle:${SYMFONY_VERSION} --prefer-source
+  - composer require symfony/framework-bundle:${SYMFONY_VERSION} $COMPOSER_FLAGS
 
 script:
   - make test

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ php:
   - nightly
 
 env:
-  - SYMFONY_VERSION=2.6.*
+  - SYMFONY_VERSION=2.7.*
 
 matrix:
   include:
@@ -17,11 +17,14 @@ matrix:
     - php: 5.6
       env: SYMFONY_VERSION=2.3.*
     - php: 5.6
-      env: SYMFONY_VERSION=2.5.*
+      env: SYMFONY_VERSION=2.6.*
     - php: 5.6
-      env: SYMFONY_VERSION=2.7.*@dev
+      env: SYMFONY_VERSION=2.8.*@dev
+    - php: 5.6
+      env: SYMFONY_VERSION=3.0.*@dev
   allow_failures:
-    - env: SYMFONY_VERSION=2.7.*@dev
+    - env: SYMFONY_VERSION=2.8.*@dev
+    - env: SYMFONY_VERSION=3.0.*@dev
     - php: nightly
 
 before_install:

--- a/Tests/bootstrap.php
+++ b/Tests/bootstrap.php
@@ -14,3 +14,9 @@ if (file_exists($file = __DIR__.'/autoload.php')) {
 } elseif (file_exists($file = __DIR__.'/autoload.php.dist')) {
     require_once $file;
 }
+
+// Early versions of Twig did not use the Composer autoloader; load Twig's autoloader if necessary
+if (!class_exists('Twig_Extension')) {
+    require_once __DIR__.'/../vendor/twig/twig/lib/Twig/Autoloader.php';
+    Twig_Autoloader::register();
+}

--- a/composer.json
+++ b/composer.json
@@ -14,8 +14,8 @@
     ],
     "require-dev": {
         "silex/silex": "~1.0",
-        "symfony/framework-bundle": "~2.2",
-        "symfony/console": "~2.2",
+        "symfony/framework-bundle": "~2.2|~3.0",
+        "symfony/console": "~2.2|~3.0",
         "twig/twig": "1.*"
     },
     "suggest": {


### PR DESCRIPTION
This pull makes some updates to the CI integration and `composer.json` for Symfony 2.8 & 3.0.

- `composer.json` is updated to allow 3.0 packages
- Travis-CI updates:
    - Default test branch is now the 2.7 LTS branch
    - Test support is removed for the EOL 2.5 branch
    - Test support is added for the 2.8 and 3.0 development branches 
    - The `COMPOSER_FLAGS` environmental variable wasn't used, implemented it
    - Since `--prefer-lowest` isn't an option on `composer require`, adjusted the install script to call `composer update` which supports it
- Register `Twig_Autoloader` if Twig hasn't registered to Composer's autoloader (required for the `--prefer-lowest` run)