### PR TITLE
Fix the build on PHP 5.3.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,8 @@ env:
 
 matrix:
   include:
-    - php: 5.3.3
-      env: SYMFONY_VERSION=2.3.* COMPOSER_FLAGS="--prefer-lowest --prefer-source"
+    - php: 5.3.4
+      env: SYMFONY_VERSION=2.3.* COMPOSER_FLAGS="--prefer-lowest"
     - php: 5.6
       env: SYMFONY_VERSION=2.3.* COMPOSER_FLAGS="--prefer-source"
     - php: 5.6

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ env:
 matrix:
   include:
     - php: 5.3.3
-      env: SYMFONY_VERSION=2.3.* COMPOSER_FLAGS="--prefer-lowest"
+      env: SYMFONY_VERSION=2.3.* COMPOSER_FLAGS="--prefer-lowest --prefer-source"
     - php: 5.6
       env: SYMFONY_VERSION=2.3.* COMPOSER_FLAGS="--prefer-source"
     - php: 5.6

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ env:
 
 matrix:
   include:
-    - php: 5.3.4
+    - php: 5.3
       env: SYMFONY_VERSION=2.3.* COMPOSER_FLAGS="--prefer-lowest"
     - php: 5.6
       env: SYMFONY_VERSION=2.3.* COMPOSER_FLAGS="--prefer-source"


### PR DESCRIPTION
I have to open the PR to run the Travis build, hopefully it will work. I applied the same solution as other packages did in https://github.com/travis-ci/travis-ci/issues/1385 (openssl is missing for PHP 5.3.3).
