### PR TITLE
Inserting custom events via New Relic agent

### DIFF
--- a/Listener/ResponseListener.php
+++ b/Listener/ResponseListener.php
@@ -86,6 +86,12 @@ class ResponseListener
             }
         }
 
+        foreach ($this->newRelic->getCustomEvents() as $name => $events) {
+            foreach ($events as $attributes) {
+                $this->interactor->addCustomEvent($name, $attributes);
+            }
+        }
+
         if ($this->instrument) {
             if (null === $this->newRelicTwigExtension || false === $this->newRelicTwigExtension->isUsed()) {
                 $this->interactor->disableAutoRUM();

--- a/NewRelic/BlackholeInteractor.php
+++ b/NewRelic/BlackholeInteractor.php
@@ -37,6 +37,13 @@ class BlackholeInteractor implements NewRelicInteractorInterface
     /**
      * {@inheritdoc}
      */
+    public function addCustomEvent($name, array $attributes)
+    {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function addCustomMetric($name, $value)
     {
     }

--- a/NewRelic/LoggingInteractorDecorator.php
+++ b/NewRelic/LoggingInteractorDecorator.php
@@ -84,6 +84,15 @@ class LoggingInteractorDecorator implements NewRelicInteractorInterface
     /**
      * {@inheritdoc}
      */
+    public function addCustomEvent($name, array $attributes)
+    {
+        $this->log(sprintf('Adding custom New Relic event %s', $name), $attributes);
+        $this->interactor->addCustomEvent($name, $attributes);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function addCustomMetric($name, $value)
     {
         $this->log(sprintf('Adding custom New Relic metric %s: %s', $name, $value));

--- a/NewRelic/NewRelic.php
+++ b/NewRelic/NewRelic.php
@@ -23,6 +23,8 @@ class NewRelic
 
     protected $framework;
 
+    protected $customEvents;
+
     protected $customMetrics;
 
     protected $customParameters;
@@ -43,8 +45,34 @@ class NewRelic
         $this->licenseKey       = $licenseKey ?: ini_get('newrelic.license');
         $this->xmit             = $xmit;
         $this->deploymentNames  = $deploymentNames;
+        $this->customEvents     = array();
         $this->customMetrics    = array();
         $this->customParameters = array();
+    }
+
+    /**
+     * @param array $customEvents
+     */
+    public function setCustomEvents(array $customEvents)
+    {
+        $this->customEvents = $customEvents;
+    }
+
+    /**
+     * @return array
+     */
+    public function getCustomEvents()
+    {
+        return $this->customEvents;
+    }
+
+    /**
+     * @param string $name
+     * @param array  $attributes
+     */
+    public function addCustomEvent($name, array $attributes)
+    {
+        $this->customEvents[$name][] = $attributes;
     }
 
     /**

--- a/NewRelic/NewRelicInteractor.php
+++ b/NewRelic/NewRelicInteractor.php
@@ -40,6 +40,14 @@ class NewRelicInteractor implements NewRelicInteractorInterface
     /**
      * {@inheritdoc}
      */
+    public function addCustomEvent($name, array $attributes)
+    {
+        newrelic_record_custom_event((string) $name, $attributes);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function addCustomMetric($name, $value)
     {
         newrelic_custom_metric((string) $name, $value);

--- a/NewRelic/NewRelicInteractorInterface.php
+++ b/NewRelic/NewRelicInteractorInterface.php
@@ -34,6 +34,14 @@ interface NewRelicInteractorInterface
 
     /**
      * @param string $name
+     * @param array  $attributes
+     *
+     * @return void
+     */
+    public function addCustomEvent($name, array $attributes);
+
+    /**
+     * @param string $name
      * @param string $value
      *
      * @return void

--- a/Tests/NewRelic/NewRelicTest.php
+++ b/Tests/NewRelic/NewRelicTest.php
@@ -23,8 +23,27 @@ class NewRelicTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('Ekino', $newRelic->getName());
         $this->assertEquals('XXX', $newRelic->getApiKey());
 
+        $this->assertEmpty($newRelic->getCustomEvents());
         $this->assertEmpty($newRelic->getCustomMetrics());
         $this->assertEmpty($newRelic->getCustomParameters());
+
+        $newRelic->addCustomEvent('WidgetSale', array('color' => 'red', 'weight' => 12.5));
+        $newRelic->addCustomEvent('WidgetSale', array('color' => 'blue', 'weight' => 12.5));
+
+        $expected = array(
+            'WidgetSale' => array(
+                array(
+                    'color' => 'red',
+                    'weight' => 12.5,
+                ),
+                array(
+                    'color' => 'blue',
+                    'weight' => 12.5,
+                ),
+            ),
+        );
+
+        $this->assertEquals($expected, $newRelic->getCustomEvents());
 
         $newRelic->addCustomMetric('foo', 'bar');
         $newRelic->addCustomMetric('asd', 1);


### PR DESCRIPTION
PR to implement [inserting custom events via New Relic APM agent](https://docs.newrelic.com/docs/insights/new-relic-insights/adding-querying-data/inserting-custom-events-new-relic-apm-agents).

> Note: `newrelic_record_custom_event()` is available via the PHP agent as of v4.18.

In order to allow for multiple custom events with the same name in a single transaction, the custom events are stored on the `NewRelic` object as a multi-dimensional array, where the top-level array keys are the event names, and the nested arrays are the individual event attributes.

This differs slightly from the format used when sending custom events through the [Insights API](https://docs.newrelic.com/docs/insights/new-relic-insights/adding-querying-data/insert-custom-events-insights-api#json-format), but aligns with the existing functionality for adding custom metrics and parameters.
