### PR TITLE
Replace deprecated ConsoleException by ConsolerError

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,40 +1,39 @@
 language: php
 
 php:
-  - 5.3
-  - 5.4
   - 5.5
   - 5.6
+  - 7.0
+  - 7.1
   - nightly
 
 env:
-  - SYMFONY_VERSION=2.7.* COMPOSER_FLAGS="--prefer-source"
+  - SYMFONY_VERSION=3.0.* SYMFONY_CONSOLE_VERSION=3.3.*
 
 matrix:
   include:
-    - php: 5.3.3
+    - php: 5.3
       env: SYMFONY_VERSION=2.3.* COMPOSER_FLAGS="--prefer-lowest"
-    - php: 5.6
-      env: SYMFONY_VERSION=2.3.* COMPOSER_FLAGS="--prefer-source"
-    - php: 5.6
-      env: SYMFONY_VERSION=2.6.* COMPOSER_FLAGS="--prefer-source"
-    - php: 5.6
-      env: SYMFONY_VERSION=2.8.*@dev COMPOSER_FLAGS=""
-    - php: 5.6
-      env: SYMFONY_VERSION=3.0.*@dev COMPOSER_FLAGS=""
+    - php: 5.4
+      env: SYMFONY_VERSION=2.3.* COMPOSER_FLAGS=""
+    - php: 7.1
+      env: SYMFONY_VERSION=2.3.*
+    - php: 7.1
+      env: SYMFONY_VERSION=2.7.*
+    - php: 7.1
+      env: SYMFONY_VERSION=2.8.*
+    - php: 7.1
+      env: SYMFONY_VERSION=3.0.*
   allow_failures:
-    - env: SYMFONY_VERSION=2.8.*@dev COMPOSER_FLAGS=""
-    - env: SYMFONY_VERSION=3.0.*@dev COMPOSER_FLAGS=""
     - php: nightly
 
 before_install:
   - composer self-update
-  - if [ "$SYMFONY_VERSION" = "2.8.*@dev" ] || [ "$SYMFONY_VERSION" = "3.0.*@dev" ]; then perl -pi -e 's/^}$/,"minimum-stability":"dev"}/' composer.json; fi;
 
 install:
   - composer require symfony/framework-bundle:${SYMFONY_VERSION} --no-update
-  - composer require symfony/console:${SYMFONY_VERSION} --no-update
-  - composer update $COMPOSER_FLAGS
+  - composer require symfony/console:${SYMFONY_CONSOLE_VERSION:-${SYMFONY_VERSION}} --no-update
+  - composer update ${COMPOSER_FLAGS}
 
 script:
   - make test

--- a/DependencyInjection/EkinoNewRelicExtension.php
+++ b/DependencyInjection/EkinoNewRelicExtension.php
@@ -11,12 +11,11 @@
 
 namespace  Ekino\Bundle\NewRelicBundle\DependencyInjection;
 
-use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\Config\FileLocator;
-use Symfony\Component\DependencyInjection\Definition;
-use Symfony\Component\HttpKernel\DependencyInjection\Extension;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader;
 use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 
 /**
  * This is the class that loads and manages your bundle configuration

--- a/Exception/ThrowableException.php
+++ b/Exception/ThrowableException.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of Ekino New Relic bundle.
+ *
+ * (c) Ekino - Thomas Rabaix <thomas.rabaix@ekino.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace  Ekino\Bundle\NewRelicBundle\Exception;
+
+/**
+ * Encapsulate a \Throwable into an \Exception
+ */
+class ThrowableException extends \ErrorException
+{
+    public function __construct(\Throwable $throwable)
+    {
+        parent::__construct($throwable->getMessage(), $throwable->getCode(), 1, $throwable->getFile(), $throwable->getLine(), $throwable);
+    }
+}

--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,2 @@
 test:
-	phpunit
+	./vendor/bin/phpunit

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -58,8 +58,7 @@
         </service>
 
         <service id="ekino.new_relic.command_listener" class="Ekino\Bundle\NewRelicBundle\Listener\CommandListener">
-            <tag name="kernel.event_listener" event="console.command" method="onConsoleCommand" priority="0"/>
-            <tag name="kernel.event_listener" event="console.exception" method="onConsoleException" priority="0"/>
+            <tag name="kernel.event_subscriber"/>
 
             <argument type="service" id="ekino.new_relic" />
             <argument type="service" id="ekino.new_relic.interactor" />

--- a/Silex/EkinoNewRelicServiceProvider.php
+++ b/Silex/EkinoNewRelicServiceProvider.php
@@ -111,7 +111,7 @@ class EkinoNewRelicServiceProvider implements ServiceProviderInterface
         }
 
         if ($app['new_relic.log_exceptions'] && $app['new_relic.log_commands']) {
-            $app['dispatcher']->addListener(ConsoleEvents::EXCEPTION, array($app['new_relic.console_listener'], 'onConsoleException'), 0);
+            $app['dispatcher']->addSubscriber($app['new_relic.console_listener']);
         }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,8 @@
         "silex/silex": "~1.0",
         "symfony/framework-bundle": "~2.2|~3.0",
         "symfony/console": "~2.2|~3.0",
-        "twig/twig": "1.*"
+        "twig/twig": "1.*",
+        "phpunit/phpunit": "^4.8"
     },
     "suggest": {
         "sonata-project/block-bundle": "2.2.*@dev"


### PR DESCRIPTION
Given I need php 7 and Symfony 3.3 to fully test this feature, I also made few changes in the travis.yml file.

Tell me if you prefer a separate PR