### PR TITLE
Use psr-4 autoloading, remove EOL symfony versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,11 +13,9 @@ env:
 matrix:
   include:
     - php: 5.3
-      env: SYMFONY_VERSION=2.3.* COMPOSER_FLAGS="--prefer-lowest"
+      env: SYMFONY_VERSION=2.7.* COMPOSER_FLAGS="--prefer-lowest"
     - php: 5.4
-      env: SYMFONY_VERSION=2.3.* COMPOSER_FLAGS=""
-    - php: 7.1
-      env: SYMFONY_VERSION=2.3.*
+      env: SYMFONY_VERSION=2.7.* COMPOSER_FLAGS=""
     - php: 7.1
       env: SYMFONY_VERSION=2.7.*
     - php: 7.1

--- a/README.md
+++ b/README.md
@@ -44,32 +44,8 @@ review http://newrelic.com ...
 
 ### Step 1: add dependency
 
-Use `composer.phar`:
-
 ```bash
-$ php composer.phar require ekino/newrelic-bundle
-```
-You just have to specify the version you want : `master-dev`.
-It will add the package in your `composer.json` file and install it.
-
-Or you can do it by yourself, first, add the following to your `composer.json` file:
-
-```js
-// composer.json
-{
-    // ...
-    require: {
-        // ...
-        "ekino/newrelic-bundle": "master-dev"
-    }
-}
-```
-
-Then, you can install the new dependencies by running Composer's ``update``
-command from the directory where your ``composer.json`` file is located:
-
-```bash
-$ php composer.phar update ekino/newrelic-bundle
+$ composer require ekino/newrelic-bundle
 ```
 
 ### Step 2 : Register the bundle

--- a/Twig/NewRelicExtension.php
+++ b/Twig/NewRelicExtension.php
@@ -60,14 +60,6 @@ class NewRelicExtension extends \Twig_Extension
     }
 
     /**
-     * @return string
-     */
-    public function getName()
-    {
-        return 'ekino_newrelic_extension';
-    }
-
-    /**
      * @return array
      */
     public function getFunctions()

--- a/composer.json
+++ b/composer.json
@@ -12,23 +12,28 @@
             "homepage": "http://ekino.com"
         }
     ],
+    "require": {
+        "php": ">=5.3"
+    },
     "require-dev": {
-        "silex/silex": "~1.0",
-        "symfony/framework-bundle": "~2.2|~3.0",
-        "symfony/console": "~2.2|~3.0",
-        "twig/twig": "1.*",
+        "silex/silex": "^1.0",
+        "symfony/framework-bundle": "^2.7|^3.0",
+        "symfony/console": "^2.7|^3.0",
+        "twig/twig": "^1.26|^2.0",
         "phpunit/phpunit": "^4.8"
+    },
+    "conflict": {
+        "twig/twig": "<1.26"
     },
     "suggest": {
         "sonata-project/block-bundle": "2.2.*@dev"
     },
     "autoload": {
-        "psr-0": { "Ekino\\Bundle\\NewRelicBundle": "" }
+        "psr-4": { "Ekino\\Bundle\\NewRelicBundle\\": "" }
     },
-    "target-dir": "Ekino/Bundle/NewRelicBundle",
     "extra": {
         "branch-alias": {
-            "dev-master": "1.3-dev"
+            "dev-master": "1.4-dev"
         }
     }
 }


### PR DESCRIPTION
I'd propose to release this PR and #118 as version 1.4 and then remove support for outdated php versions for 1.5 version.