### PR TITLE
Only master requests should be processed by the ResponseListener.

### DIFF
--- a/Listener/ResponseListener.php
+++ b/Listener/ResponseListener.php
@@ -76,6 +76,10 @@ class ResponseListener
      */
     public function onCoreResponse(FilterResponseEvent $event)
     {
+        if (!$event->isMasterRequest()) {
+            return;
+        }
+
         if (null === $this->newRelicTwigExtension || false === $this->newRelicTwigExtension->isUsed()) {
             foreach ($this->newRelic->getCustomMetrics() as $name => $value) {
                 $this->interactor->addCustomMetric((string) $name, (float) $value);


### PR DESCRIPTION
Hi,

This PR should ensure that only master requests are handled by the `ResponseListener`. Sub-requests should be ignored.

I think that we need to avoid sub-requests because we only care about [master requests](https://github.com/ekino/EkinoNewRelicBundle/blob/master/Listener/RequestListener.php#L125) when starting NR transactions. That means that we must [end transaction](https://github.com/ekino/EkinoNewRelicBundle/blob/00f68a6bf836afeee9d83ac5e6b4087b89370b89/Listener/ResponseListener.php#L118) only if the request is a master one. If we process sub-requests in `ResponseListener` then we will accidentally, prematurely, end the master request transaction.

In other words, we always need to process _only_ master requests. This is already the case with `RequestListener` and now I fixed `ResponseListener` so no sub-requests can prematurely end our NR transactions.

Please let me know if I'm wrong. Thanks!