### PR TITLE
Allow you to specify an interactor service

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -31,6 +31,7 @@ class Configuration implements ConfigurationInterface
             ->fixXmlConfig('log_log')
             ->children()
                 ->booleanNode('enabled')->defaultTrue()->end()
+                ->scalarNode('interactor')->end()
                 ->booleanNode('twig')->defaultValue(class_exists('\Twig_Environment'))->end()
                 ->scalarNode('api_key')->defaultValue(false)->end()
                 ->scalarNode('license_key')->defaultValue(null)->end()

--- a/DependencyInjection/EkinoNewRelicExtension.php
+++ b/DependencyInjection/EkinoNewRelicExtension.php
@@ -47,9 +47,16 @@ class EkinoNewRelicExtension extends Extension
         $container->getDefinition('ekino.new_relic.command_listener')
             ->replaceArgument(2, $config['ignored_commands']);
 
-        $interactor = $config['enabled'] && extension_loaded('newrelic')
-            ? 'ekino.new_relic.interactor.real'
-            : 'ekino.new_relic.interactor.blackhole';
+        if (!$config['enabled']) {
+            $interactor = 'ekino.new_relic.interactor.blackhole';
+        } elseif (isset($config['interactor'])) {
+            $interactor = $config['interactor'];
+        } else {
+            // Fallback to see if the extension is loaded or not
+            $interactor = extension_loaded('newrelic')
+                ? 'ekino.new_relic.interactor.real'
+                : 'ekino.new_relic.interactor.blackhole';
+        }
 
         if ($config['logging']) {
             $container->setAlias('ekino.new_relic.interactor', 'ekino.new_relic.interactor.logger');

--- a/NewRelic/AutoInteractor.php
+++ b/NewRelic/AutoInteractor.php
@@ -21,13 +21,25 @@ namespace Ekino\Bundle\NewRelicBundle\NewRelic;
 class AutoInteractor implements NewRelicInteractorInterface
 {
     /**
+     * @var NewRelicInteractorInterface
+     */
+    private $interactor;
+
+    /**
+     * @param NewRelicInteractorInterface $interactor
+     */
+    public function __construct(NewRelicInteractorInterface $real, NewRelicInteractorInterface $fake)
+    {
+        $this->interactor = extension_loaded('newrelic') ? $real : $fake;
+    }
+
+
+    /**
      * {@inheritdoc}
      */
     public function setApplicationName($name, $key = null, $xmit = false)
     {
-        if (function_exists('newrelic_set_appname')) {
-            newrelic_set_appname($name, $key, $xmit);
-        }
+        $this->interactor->setApplicationName($name, $key, $xmit);
     }
 
     /**
@@ -35,9 +47,7 @@ class AutoInteractor implements NewRelicInteractorInterface
      */
     public function setTransactionName($name)
     {
-        if (function_exists('newrelic_name_transaction')) {
-            newrelic_name_transaction($name);
-        }
+        $this->interactor->setTransactionName($name);
     }
 
     /**
@@ -45,9 +55,7 @@ class AutoInteractor implements NewRelicInteractorInterface
      */
     public function ignoreTransaction ()
     {
-        if (function_exists('newrelic_ignore_transaction')) {
-            newrelic_ignore_transaction();
-        }
+        $this->interactor->ignoreTransaction();
     }
 
     /**
@@ -55,9 +63,7 @@ class AutoInteractor implements NewRelicInteractorInterface
      */
     public function addCustomMetric($name, $value)
     {
-        if (function_exists('newrelic_custom_metric')) {
-            newrelic_custom_metric((string) $name, $value);
-        }
+        $this->interactor->addCustomMetric($name, $value);
     }
 
     /**
@@ -65,9 +71,7 @@ class AutoInteractor implements NewRelicInteractorInterface
      */
     public function addCustomParameter($name, $value)
     {
-        if (function_exists('newrelic_add_custom_parameter')) {
-            newrelic_add_custom_parameter((string) $name, $value);
-        }
+        $this->interactor->addCustomParameter($name, $value);
     }
 
     /**
@@ -75,9 +79,7 @@ class AutoInteractor implements NewRelicInteractorInterface
      */
     public function getBrowserTimingHeader()
     {
-        if (function_exists('newrelic_get_browser_timing_header')) {
-            return newrelic_get_browser_timing_header();
-        }
+        return $this->interactor->getBrowserTimingHeader();
     }
 
     /**
@@ -85,9 +87,7 @@ class AutoInteractor implements NewRelicInteractorInterface
      */
     public function getBrowserTimingFooter()
     {
-        if (function_exists('newrelic_get_browser_timing_footer')) {
-            return newrelic_get_browser_timing_footer();
-        }
+        return $this->interactor->getBrowserTimingFooter();
     }
 
     /**
@@ -95,9 +95,7 @@ class AutoInteractor implements NewRelicInteractorInterface
      */
     public function disableAutoRUM()
     {
-        if (function_exists('newrelic_disable_autorum')) {
-            return newrelic_disable_autorum();
-        }
+        $this->interactor->disableAutoRUM();
     }
 
     /**
@@ -105,9 +103,7 @@ class AutoInteractor implements NewRelicInteractorInterface
      */
     public function noticeError($msg)
     {
-        if (function_exists('newrelic_notice_error')) {
-            return newrelic_notice_error($msg);
-        }
+        $this->interactor->noticeError($msg);
     }
 
     /**
@@ -115,9 +111,7 @@ class AutoInteractor implements NewRelicInteractorInterface
      */
     public function noticeException(\Exception $e)
     {
-        if (function_exists('newrelic_notice_error')) {
-            return newrelic_notice_error(null, $e);
-        }
+        $this->interactor->noticeError($e);
     }
 
     /**
@@ -125,9 +119,7 @@ class AutoInteractor implements NewRelicInteractorInterface
      */
     public function enableBackgroundJob()
     {
-        if (function_exists('newrelic_background_job')) {
-            return newrelic_background_job(true);
-        }
+        $this->interactor->enableBackgroundJob();
     }
 
     /**
@@ -135,9 +127,7 @@ class AutoInteractor implements NewRelicInteractorInterface
      */
     public function disableBackgroundJob()
     {
-        if (function_exists('newrelic_background_job')) {
-            return newrelic_background_job(false);
-        }
+        $this->interactor->disableBackgroundJob();
     }
 
     /**
@@ -145,9 +135,7 @@ class AutoInteractor implements NewRelicInteractorInterface
      */
     public function endTransaction()
     {
-        if (function_exists('newrelic_end_transaction')) {
-            return newrelic_end_transaction(false);
-        }
+        $this->interactor->endTransaction();
     }
 
     /**
@@ -155,8 +143,6 @@ class AutoInteractor implements NewRelicInteractorInterface
      */
     public function startTransaction($name)
     {
-        if (function_exists('newrelic_start_transaction')) {
-            return newrelic_start_transaction($name);
-        }
+        $this->interactor->startTransaction($name);
     }
 }

--- a/NewRelic/AutoInteractor.php
+++ b/NewRelic/AutoInteractor.php
@@ -33,116 +33,113 @@ class AutoInteractor implements NewRelicInteractorInterface
         $this->interactor = extension_loaded('newrelic') ? $real : $fake;
     }
 
-
-    /**
-     * {@inheritdoc}
-     */
-    public function setApplicationName($name, $key = null, $xmit = false)
+    public function setApplicationName(string $name, string $license = null, bool $xmit = false): bool
     {
-        $this->interactor->setApplicationName($name, $key, $xmit);
+        return $this->interactor->setApplicationName($name, $license, $xmit);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function setTransactionName($name)
+    public function setTransactionName(string $name): bool
     {
-        $this->interactor->setTransactionName($name);
+        return $this->interactor->setTransactionName($name);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function ignoreTransaction ()
+    public function ignoreTransaction(): void
     {
         $this->interactor->ignoreTransaction();
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function addCustomMetric($name, $value)
+    public function addCustomEvent(string $name, array $attributes): void
     {
-        $this->interactor->addCustomMetric($name, $value);
+        $this->interactor->addCustomEvent($name, $attributes);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function addCustomParameter($name, $value)
+    public function addCustomMetric(string $name, float $value): bool
     {
-        $this->interactor->addCustomParameter($name, $value);
+        return $this->interactor->addCustomMetric($name, $value);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getBrowserTimingHeader()
+    public function addCustomParameter(string $name, $value): bool
     {
-        return $this->interactor->getBrowserTimingHeader();
+        return $this->interactor->addCustomParameter($name, $value);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getBrowserTimingFooter()
+    public function getBrowserTimingHeader(bool $includeTags = true): string
     {
-        return $this->interactor->getBrowserTimingFooter();
+        return $this->interactor->getBrowserTimingHeader($includeTags);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function disableAutoRUM()
+    public function getBrowserTimingFooter(bool $includeTags = true): string
     {
-        $this->interactor->disableAutoRUM();
+        return $this->interactor->getBrowserTimingFooter($includeTags);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function noticeError($msg)
+    public function disableAutoRUM(): bool
     {
-        $this->interactor->noticeError($msg);
+        return $this->interactor->disableAutoRUM();
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function noticeException(\Exception $e)
+    public function noticeThrowable(\Throwable $e, string $message = null): void
     {
-        $this->interactor->noticeError($e);
+        $this->interactor->noticeThrowable($e, $message);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function enableBackgroundJob()
+    public function noticeError(
+        int $errno,
+        string $errstr,
+        string $errfile = null,
+        int $errline = null,
+        string $errcontext = null
+    ): void {
+        $this->interactor->noticeError($errno, $errstr, $errfile, $errline, $errcontext);
+    }
+
+    public function enableBackgroundJob(): void
     {
         $this->interactor->enableBackgroundJob();
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function disableBackgroundJob()
+    public function disableBackgroundJob(): void
     {
         $this->interactor->disableBackgroundJob();
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function endTransaction()
+    public function startTransaction(string $name = null, string $license = null): bool
     {
-        $this->interactor->endTransaction();
+        return $this->interactor->startTransaction($name, $license);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function startTransaction($name)
+    public function endTransaction(bool $ignore = false): bool
     {
-        $this->interactor->startTransaction($name);
+        return $this->interactor->endTransaction($ignore);
+    }
+
+    public function excludeFromApdex(): void
+    {
+        $this->interactor->excludeFromApdex();
+    }
+
+    public function addCustomTracer(string $name): bool
+    {
+        return $this->interactor->addCustomTracer($name);
+    }
+
+    public function setCaptureParams(bool $enabled): void
+    {
+        $this->interactor->setCaptureParams($enabled);
+    }
+
+    public function stopTransactionTiming(): void
+    {
+        $this->interactor->stopTransactionTiming();
+    }
+
+    public function recordDatastoreSegment(callable $func, array $parameters)
+    {
+        return $this->interactor->recordDatastoreSegment($func, $parameters);
+    }
+
+    public function setUserAttributes(string $userValue, string $accountValue, string $productValue): bool
+    {
+        return $this->interactor->setUserAttributes($userValue, $accountValue, $productValue);
     }
 }

--- a/NewRelic/AutoInteractor.php
+++ b/NewRelic/AutoInteractor.php
@@ -1,0 +1,162 @@
+<?php
+
+/*
+ * This file is part of Ekino New Relic bundle.
+ *
+ * (c) Ekino - Thomas Rabaix <thomas.rabaix@ekino.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Ekino\Bundle\NewRelicBundle\NewRelic;
+
+/**
+ * This interactor does never assume that the NewRelic extension is installed. It will check
+ * for the existence of each method EVERY time. This is a good interactor to use when you want
+ * to enable and disable the NewRelic extension without rebuilding your container.
+ *
+ * @author Tobias Nyholm <tobias.nyholm@gmail.com>
+ */
+class AutoInteractor implements NewRelicInteractorInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function setApplicationName($name, $key = null, $xmit = false)
+    {
+        if (function_exists('newrelic_set_appname')) {
+            newrelic_set_appname($name, $key, $xmit);
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setTransactionName($name)
+    {
+        if (function_exists('newrelic_name_transaction')) {
+            newrelic_name_transaction($name);
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function ignoreTransaction ()
+    {
+        if (function_exists('newrelic_ignore_transaction')) {
+            newrelic_ignore_transaction();
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function addCustomMetric($name, $value)
+    {
+        if (function_exists('newrelic_custom_metric')) {
+            newrelic_custom_metric((string) $name, $value);
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function addCustomParameter($name, $value)
+    {
+        if (function_exists('newrelic_add_custom_parameter')) {
+            newrelic_add_custom_parameter((string) $name, $value);
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getBrowserTimingHeader()
+    {
+        if (function_exists('newrelic_get_browser_timing_header')) {
+            return newrelic_get_browser_timing_header();
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getBrowserTimingFooter()
+    {
+        if (function_exists('newrelic_get_browser_timing_footer')) {
+            return newrelic_get_browser_timing_footer();
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function disableAutoRUM()
+    {
+        if (function_exists('newrelic_disable_autorum')) {
+            return newrelic_disable_autorum();
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function noticeError($msg)
+    {
+        if (function_exists('newrelic_notice_error')) {
+            return newrelic_notice_error($msg);
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function noticeException(\Exception $e)
+    {
+        if (function_exists('newrelic_notice_error')) {
+            return newrelic_notice_error(null, $e);
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function enableBackgroundJob()
+    {
+        if (function_exists('newrelic_background_job')) {
+            return newrelic_background_job(true);
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function disableBackgroundJob()
+    {
+        if (function_exists('newrelic_background_job')) {
+            return newrelic_background_job(false);
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function endTransaction()
+    {
+        if (function_exists('newrelic_end_transaction')) {
+            return newrelic_end_transaction(false);
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function startTransaction($name)
+    {
+        if (function_exists('newrelic_start_transaction')) {
+            return newrelic_start_transaction($name);
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ ekino_new_relic:
     ignored_routes: []                    # No transaction recorded for this routes
     ignored_paths: []                     # No transaction recorded for this paths
     ignored_commands: []                  # No transaction recorded for this commands (background tasks)
+    interactor: ~                         # The interactor service that is used. Setting enabled=false will override this value 
     twig: true                            # Allows you to disable twig integration (falls back to class_exists(\Twig_Environment::class))
 ```
 

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -31,7 +31,10 @@
         <!-- Default alias -->
         <service id="ekino.new_relic.interactor" alias="ekino.new_relic.interactor.blackhole" />
         <!-- Help auto complete -->
-        <service id="Ekino\Bundle\NewRelicBundle\NewRelic\NewRelicInteractorInterface" alias="ekino.new_relic.interactor" />
+        <service id="Ekino\Bundle\NewRelicBundle\NewRelic\NewRelicInteractorInterface" alias="ekino.new_relic.interactor">
+            <argument type="service" id="ekino.new_relic.interactor.real" />
+            <argument type="service" id="ekino.new_relic.interactor.blackhole" />
+        </service>
 
         <service id="ekino.new_relic.interactor.logger" class="Ekino\Bundle\NewRelicBundle\NewRelic\LoggingInteractorDecorator" public="false">
             <argument type="service" id="ekino.new_relic.interactor.real" />

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -26,7 +26,10 @@
 
         <service id="ekino.new_relic.interactor.real" class="Ekino\Bundle\NewRelicBundle\NewRelic\NewRelicInteractor" public="false" />
         <service id="ekino.new_relic.interactor.blackhole" class="Ekino\Bundle\NewRelicBundle\NewRelic\BlackholeInteractor" public="false" />
-        <service id="ekino.new_relic.interactor.auto" class="Ekino\Bundle\NewRelicBundle\NewRelic\AutoInteractor" public="false" />
+        <service id="ekino.new_relic.interactor.auto" class="Ekino\Bundle\NewRelicBundle\NewRelic\AutoInteractor" public="false">
+            <argument type="service" id="ekino.new_relic.interactor.real" />
+            <argument type="service" id="ekino.new_relic.interactor.blackhole" />
+        </service>
 
         <!-- Default alias -->
         <service id="ekino.new_relic.interactor" alias="ekino.new_relic.interactor.blackhole" />

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -26,6 +26,7 @@
 
         <service id="ekino.new_relic.interactor.real" class="Ekino\Bundle\NewRelicBundle\NewRelic\NewRelicInteractor" public="false" />
         <service id="ekino.new_relic.interactor.blackhole" class="Ekino\Bundle\NewRelicBundle\NewRelic\BlackholeInteractor" public="false" />
+        <service id="ekino.new_relic.interactor.auto" class="Ekino\Bundle\NewRelicBundle\NewRelic\AutoInteractor" public="false" />
 
         <!-- Default alias -->
         <service id="ekino.new_relic.interactor" alias="ekino.new_relic.interactor.blackhole" />

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -34,10 +34,7 @@
         <!-- Default alias -->
         <service id="ekino.new_relic.interactor" alias="ekino.new_relic.interactor.blackhole" />
         <!-- Help auto complete -->
-        <service id="Ekino\Bundle\NewRelicBundle\NewRelic\NewRelicInteractorInterface" alias="ekino.new_relic.interactor">
-            <argument type="service" id="ekino.new_relic.interactor.real" />
-            <argument type="service" id="ekino.new_relic.interactor.blackhole" />
-        </service>
+        <service id="Ekino\Bundle\NewRelicBundle\NewRelic\NewRelicInteractorInterface" alias="ekino.new_relic.interactor" />
 
         <service id="ekino.new_relic.interactor.logger" class="Ekino\Bundle\NewRelicBundle\NewRelic\LoggingInteractorDecorator" public="false">
             <argument type="service" id="ekino.new_relic.interactor.real" />

--- a/Tests/DependencyInjection/EkinoNewRelicExtensionTest.php
+++ b/Tests/DependencyInjection/EkinoNewRelicExtensionTest.php
@@ -67,4 +67,33 @@ class EkinoNewRelicExtensionTest extends AbstractExtensionTestCase
         $this->assertContainerBuilderHasService('ekino.new_relic.logs_handler');
         $this->assertContainerBuilderHasServiceDefinitionWithArgument('ekino.new_relic.logs_handler', 0, 400);
     }
+
+    public function testConfigDisabled()
+    {
+        $this->load([
+            'enabled' => false,
+        ]);
+
+        $this->assertContainerBuilderHasAlias('ekino.new_relic.interactor', 'ekino.new_relic.interactor.blackhole');
+    }
+
+    public function testConfigDisabledWithInteractor()
+    {
+        $this->load([
+            'enabled' => false,
+            'interactor' => 'ekino.new_relic.interactor.auto',
+        ]);
+
+        $this->assertContainerBuilderHasAlias('ekino.new_relic.interactor', 'ekino.new_relic.interactor.blackhole');
+    }
+
+    public function testConfigEnabledWithInteractor()
+    {
+        $this->load([
+            'enabled' => true,
+            'interactor' => 'ekino.new_relic.interactor.auto',
+        ]);
+
+        $this->assertContainerBuilderHasAlias('ekino.new_relic.interactor', 'ekino.new_relic.interactor.auto');
+    }
 }


### PR DESCRIPTION
This will fix #127. 

-------

EDIT: 
I know that this is super weird. But checking #127 and possible #82 this make sense. 
The use case is when you have your deployed application with the container built, and then for some reason you unload the NewRelic extension (strange, yes). 

If you have this scenario, then you want to postpone the decision of using blackhole or not to runtime instead of build time. 
