### PR TITLE
Add a log handler

### DIFF
--- a/DependencyInjection/Compiler/MonologHandlerPass.php
+++ b/DependencyInjection/Compiler/MonologHandlerPass.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Ekino\Bundle\NewRelicBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+
+class MonologHandlerPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container)
+    {
+        if (!$container->hasParameter('ekino.new_relic.log_logs') || !$container->hasDefinition('monolog.logger')) {
+            return;
+        }
+
+        $config = $container->getParameter('ekino.new_relic.log_logs');
+        foreach ($config['channels'] as $channel) {
+            $def = $container->getDefinition($channel === 'app' ? 'monolog.logger' : 'monolog.logger.'.$channel);
+            $def->addMethodCall('pushHandler', array(new Reference('ekino.new_relic.logs_handler')));
+        }
+    }
+}

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -11,6 +11,7 @@
 
 namespace Ekino\Bundle\NewRelicBundle\DependencyInjection;
 
+use Psr\Log\LogLevel;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
 
@@ -27,6 +28,7 @@ class Configuration implements ConfigurationInterface
 
         $rootNode
             ->fixXmlConfig('deployment_name')
+            ->fixXmlConfig('log_log')
             ->children()
                 ->booleanNode('enabled')->defaultTrue()->end()
                 ->booleanNode('twig')->defaultValue(class_exists('\Twig_Environment'))->end()
@@ -56,6 +58,18 @@ class Configuration implements ConfigurationInterface
                 ->end()
                 ->booleanNode('log_commands')
                     ->defaultTrue()
+                ->end()
+                ->arrayNode('log_logs')
+                    ->canBeEnabled()
+                    ->fixXmlConfig('channel')
+                    ->children()
+                        ->arrayNode('channels')
+                            ->prototype('scalar')->end()
+                            ->defaultValue(['app'])
+                        ->end()
+                        ->scalarNode('level')->defaultValue(LogLevel::ERROR)->end()
+                        ->scalarNode('service')->defaultValue('ekino.new_relic.logs_handler.real')->end()
+                    ->end()
                 ->end()
                 ->scalarNode('transaction_naming')
                     ->defaultValue('route')

--- a/EkinoNewRelicBundle.php
+++ b/EkinoNewRelicBundle.php
@@ -11,10 +11,19 @@
 
 namespace Ekino\Bundle\NewRelicBundle;
 
+use Ekino\Bundle\NewRelicBundle\DependencyInjection\Compiler\MonologHandlerPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 class EkinoNewRelicBundle extends Bundle
 {
+    public function build(ContainerBuilder $container)
+    {
+        parent::build($container);
+
+        $container->addCompilerPass(new MonologHandlerPass());
+    }
+
     public function boot()
     {
         parent::boot();
@@ -24,3 +33,4 @@ class EkinoNewRelicBundle extends Bundle
         }
     }
 }
+

--- a/Logging/AutoHandler.php
+++ b/Logging/AutoHandler.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file is part of Ekino New Relic bundle.
+ *
+ * (c) Ekino - Thomas Rabaix <thomas.rabaix@ekino.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Ekino\Bundle\NewRelicBundle\Logging;
+
+use Monolog\Handler\NewRelicHandler;
+use Psr\Log\LogLevel;
+
+class AutoHandler extends NewRelicHandler
+{
+    public function __construct(
+        $level = LogLevel::ERROR,
+        $bubble = true,
+        $appName = null,
+        $explodeArrays = false,
+        $transactionName = null
+    ) {
+        parent::__construct($level, $bubble, $appName, $explodeArrays, $transactionName);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function write(array $record)
+    {
+        if (!$this->isNewRelicEnabled()) {
+            return;
+        }
+
+        return parent::write($record);
+    }
+}

--- a/README.md
+++ b/README.md
@@ -86,6 +86,11 @@ ekino_new_relic:
     instrument: false                     # If true, uses enhanced New Relic RUM instrumentation (see below) (default: false)
     log_exceptions: false                 # If true, sends exceptions to New Relic (default: false)
     log_deprecations: false               # If true, reports deprecations to New Relic (default: false)
+    log_logs: true                        # When enabled, send application's logs to New Relic (default: disabled)
+    # log_logs:                            # Advanced configuration is available
+    #    channels: [app]                   # Channels to listen (default: app)
+    #    level: error                      # Report only logs higher than this level (see \Psr\Log\LogLevel) (default: error)
+    #    service: app.my_custom_handler    # Define a custom log handler (default: ekino.new_relic.logs_handler.real)
     log_commands: true                    # If true, logs CLI commands to New Relic as Background jobs (>2.3 only) (default: true)
     using_symfony_cache: false            # Symfony HTTP cache (see below) (default: false)
     transaction_naming: route             # route, controller or service (see below)
@@ -146,12 +151,12 @@ It makes one request per `app_name`, due roll-up names are not supported by Data
 3. If no 404 was thrown we `setIgnoreTransaction` which means that we call `NewRelicInteractorInterface::ignoreTransaction()` if we have configured to ignore the route.
 4. The Firewall is the next interesting thing that will happen. It could change the controller or throw a 403.
 5. The developer might have configured many more request listeners that will now execute and possibly add stuff to the request.
-6. We will execute `setTransactionName` to use our `TransactionNamingStrategyInterface` to set a nice name. 
+6. We will execute `setTransactionName` to use our `TransactionNamingStrategyInterface` to set a nice name.
 
-All 6 steps will be executed for a normal request. Exceptions to this is 404 and 403 responses that will be created in 
-step 2 and step 4 respectively. If an exception to these step occurs (I'm not talking about `\Exception`) you will have 
+All 6 steps will be executed for a normal request. Exceptions to this is 404 and 403 responses that will be created in
+step 2 and step 4 respectively. If an exception to these step occurs (I'm not talking about `\Exception`) you will have
 the transaction logged with the correct license key but you do not have the proper transaction name. The `setTransactionName` may
-have dependencies on data set by other listeners that is why it has such low priority. 
+have dependencies on data set by other listeners that is why it has such low priority.
 
 ## Integration with SonataBlockBundle
 

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -84,5 +84,17 @@
         <service id="ekino.new_relic.deprecation_listener" class="Ekino\Bundle\NewRelicBundle\Listener\DeprecationListener" public="true">
             <argument type="service" id="ekino.new_relic.interactor"/>
         </service>
+
+        <!-- Logging -->
+        <service id="ekino.new_relic.logs_handler.auto" class="Ekino\Bundle\NewRelicBundle\Logging\AutoHandler" public="false">
+            <argument/> <!-- level -->
+            <argument>true</argument>
+            <argument/> <!-- app_name -->
+        </service>
+        <service id="ekino.new_relic.logs_handler.real" class="Monolog\Handler\NewRelicHandler" public="false">
+            <argument/> <!-- level -->
+            <argument>true</argument>
+            <argument/> <!-- app_name -->
+        </service>
     </services>
 </container>

--- a/Tests/DependencyInjection/Compiler/MonologHandlerPassTest.php
+++ b/Tests/DependencyInjection/Compiler/MonologHandlerPassTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Ekino\Bundle\NewRelicBundle\Tests\DependencyInjection\Compiler;
+
+use Ekino\Bundle\NewRelicBundle\DependencyInjection\Compiler\MonologHandlerPass;
+use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractCompilerPassTestCase;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+
+class MonologHandlerPassTest extends AbstractCompilerPassTestCase
+{
+    protected function registerCompilerPass(ContainerBuilder $container)
+    {
+        $container->addCompilerPass(new MonologHandlerPass());
+    }
+
+    public function testProcessChannel()
+    {
+        $this->container->setParameter('ekino.new_relic.log_logs', ['channels' => ['app', 'foo']]);
+        $this->registerService('monolog.logger', \Monolog\Logger::class);
+        $this->registerService('monolog.logger.foo', \Monolog\Logger::class);
+
+        $this->compile();
+
+        $this->assertContainerBuilderHasServiceDefinitionWithMethodCall('monolog.logger', 'pushHandler', [new Reference('ekino.new_relic.logs_handler')]);
+        $this->assertContainerBuilderHasServiceDefinitionWithMethodCall('monolog.logger.foo', 'pushHandler', [new Reference('ekino.new_relic.logs_handler')]);
+    }
+}

--- a/Tests/DependencyInjection/EkinoNewRelicExtensionTest.php
+++ b/Tests/DependencyInjection/EkinoNewRelicExtensionTest.php
@@ -58,4 +58,13 @@ class EkinoNewRelicExtensionTest extends AbstractExtensionTestCase
 
         $this->assertContainerBuilderHasParameter('ekino.new_relic.log_deprecations');
     }
+
+    public function testLogs()
+    {
+        $this->load(['log_logs' => true]);
+
+        $this->assertContainerBuilderHasParameter('ekino.new_relic.log_logs');
+        $this->assertContainerBuilderHasService('ekino.new_relic.logs_handler');
+        $this->assertContainerBuilderHasServiceDefinitionWithArgument('ekino.new_relic.logs_handler', 0, 400);
+    }
 }

--- a/composer.json
+++ b/composer.json
@@ -24,13 +24,15 @@
         "matthiasnoback/symfony-dependency-injection-test": "^3.0",
         "nyholm/symfony-bundle-test": "^1.3.1",
         "symfony/phpunit-bridge": "^4.0",
-        "twig/twig": "^1.32 || ^2.4"
+        "twig/twig": "^1.32 || ^2.4",
+        "symfony/monolog-bundle": "^3.2"
     },
     "conflict": {
         "twig/twig": "<1.32"
     },
     "suggest": {
-        "sonata-project/block-bundle": "2.2.*@dev"
+        "sonata-project/block-bundle": "2.2.*@dev",
+        "symfony/monolog-bundle": "^3.2"
     },
     "autoload": {
         "psr-4": { "Ekino\\Bundle\\NewRelicBundle\\": "" }


### PR DESCRIPTION
Provide a simple way to configure Monolog's NewRelicHandler

```yaml
ekino_new_relic:
  log_logs: ~
```

or a more advanced usage
```yaml
ekino_new_relic:
  log_logs:
    level: warning
    channels: [app, event]
    service: ekino.new_relic.logs_handler.auto
```

TODO:

* [x] Missing tests
