### PR TITLE
Only register the logs_handler if enabled

### DIFF
--- a/DependencyInjection/Compiler/MonologHandlerPass.php
+++ b/DependencyInjection/Compiler/MonologHandlerPass.php
@@ -15,6 +15,10 @@ class MonologHandlerPass implements CompilerPassInterface
         }
 
         $config = $container->getParameter('ekino.new_relic.log_logs');
+        if (!$config['enabled']) {
+            return;
+        }
+
         foreach ($config['channels'] as $channel) {
             $def = $container->getDefinition($channel === 'app' ? 'monolog.logger' : 'monolog.logger.'.$channel);
             $def->addMethodCall('pushHandler', array(new Reference('ekino.new_relic.logs_handler')));

--- a/Tests/DependencyInjection/Compiler/MonologHandlerPassTest.php
+++ b/Tests/DependencyInjection/Compiler/MonologHandlerPassTest.php
@@ -16,7 +16,7 @@ class MonologHandlerPassTest extends AbstractCompilerPassTestCase
 
     public function testProcessChannel()
     {
-        $this->container->setParameter('ekino.new_relic.log_logs', ['channels' => ['app', 'foo']]);
+        $this->container->setParameter('ekino.new_relic.log_logs', ['enabled' => true, 'channels' => ['app', 'foo']]);
         $this->registerService('monolog.logger', \Monolog\Logger::class);
         $this->registerService('monolog.logger.foo', \Monolog\Logger::class);
 


### PR DESCRIPTION
Fixes an issue with DIC compilation where the
`ekino.new_relic.logs_handler` service is not registered when the
log_logs config is disabled.