### PR TITLE
Fix application_name and api_key nullable

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -30,7 +30,7 @@ class Configuration implements ConfigurationInterface
                 ->booleanNode('enabled')->defaultTrue()->end()
                 ->scalarNode('interactor')->end()
                 ->booleanNode('twig')->defaultValue(\class_exists('\Twig_Environment'))->end()
-                ->scalarNode('api_key')->defaultValue(false)->end()
+                ->scalarNode('api_key')->defaultValue(null)->end()
                 ->scalarNode('license_key')->defaultValue(null)->end()
                 ->scalarNode('application_name')->defaultValue(null)->end()
                 ->arrayNode('deployment_names')

--- a/NewRelic/Config.php
+++ b/NewRelic/Config.php
@@ -27,7 +27,7 @@ class Config
     private $customParameters;
     private $deploymentNames;
 
-    public function __construct(string $name, string $apiKey, string $licenseKey = null, bool $xmit = false, array $deploymentNames = [])
+    public function __construct(?string $name, string $apiKey = null, string $licenseKey = null, bool $xmit = false, array $deploymentNames = [])
     {
         $this->name = !empty($name) ? $name : \ini_get('newrelic.appname') ?: '';
         $this->apiKey = $apiKey;
@@ -101,7 +101,7 @@ class Config
         return $this->deploymentNames;
     }
 
-    public function getApiKey(): string
+    public function getApiKey(): ?string
     {
         return $this->apiKey;
     }


### PR DESCRIPTION
As per Configuration the config `application_name` can be null.
api_key is not a boolean, and should be optional