### PR TITLE
Do not use second arguement if not set

### DIFF
--- a/NewRelic/NewRelicInteractor.php
+++ b/NewRelic/NewRelicInteractor.php
@@ -91,7 +91,7 @@ class NewRelicInteractor implements NewRelicInteractorInterface
             $name = \ini_get('newrelic.appname');
         }
 
-        if ($license === null) {
+        if (null === $license) {
             return newrelic_start_transaction($name);
         }
 

--- a/NewRelic/NewRelicInteractor.php
+++ b/NewRelic/NewRelicInteractor.php
@@ -91,6 +91,10 @@ class NewRelicInteractor implements NewRelicInteractorInterface
             $name = \ini_get('newrelic.appname');
         }
 
+        if ($license === null) {
+            return newrelic_start_transaction($name);
+        }
+
         return newrelic_start_transaction($name, $license);
     }
 


### PR DESCRIPTION
Im doing this to avoid sending an empty string to `newrelic_start_transaction`