### PR TITLE
make the deprecation listener public

### DIFF
--- a/Resources/config/deprecation_listener.xml
+++ b/Resources/config/deprecation_listener.xml
@@ -7,6 +7,6 @@
     <services>
         <defaults autowire="true" autoconfigure="true" public="false" />
 
-        <service id="Ekino\NewRelicBundle\Listener\DeprecationListener"/>
+        <service id="Ekino\NewRelicBundle\Listener\DeprecationListener" public="true" />
     </services>
 </container>


### PR DESCRIPTION
Right now the deprecation feature does not work. 

https://github.com/ekino/EkinoNewRelicBundle/blob/2.0.0-beta2/EkinoNewRelicBundle.php#L34