### PR TITLE
Fine tuning for Monolog Configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v2.0.0-beta4
+
+### Changed
+
+- Changed the configuration for monolog's channel to a configuration similar to MonologBundle. 
+
 ## v2.0.0-beta3
 
 ### Changed

--- a/DependencyInjection/Compiler/MonologHandlerPass.php
+++ b/DependencyInjection/Compiler/MonologHandlerPass.php
@@ -15,6 +15,7 @@ namespace Ekino\NewRelicBundle\DependencyInjection\Compiler;
 
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
 use Symfony\Component\DependencyInjection\Reference;
 
 class MonologHandlerPass implements CompilerPassInterface
@@ -25,10 +26,39 @@ class MonologHandlerPass implements CompilerPassInterface
             return;
         }
 
-        $channels = $container->getParameter('ekino.new_relic.monolog.channels');
+        $configuration = $container->getParameter('ekino.new_relic.monolog.channels');
+        if (null === $configuration) {
+            $channels = $this->getChannels($container);
+        } elseif ('inclusive' === $configuration['type']) {
+            $channels = $configuration['elements'] ?: $this->getChannels($container);
+        } else {
+            $channels = \array_diff($this->getChannels($container), $configuration['elements']);
+        }
+
         foreach ($channels as $channel) {
-            $def = $container->getDefinition('app' === $channel ? 'monolog.logger' : 'monolog.logger.'.$channel);
+            try {
+                $def = $container->getDefinition('app' === $channel ? 'monolog.logger' : 'monolog.logger.'.$channel);
+            } catch (InvalidArgumentException $e) {
+                $msg = 'NewRelicBundle configuration error: The logging channel "'.$channel.'" does not exist.';
+                throw new \InvalidArgumentException($msg, 0, $e);
+            }
             $def->addMethodCall('pushHandler', [new Reference('ekino.new_relic.logs_handler')]);
         }
+    }
+
+    private function getChannels(ContainerBuilder $container)
+    {
+        $channels = [];
+        foreach ($container->getDefinitions() as $id => $definition) {
+            if ('monolog.logger' === $id) {
+                $channels[] = 'app';
+                continue;
+            }
+            if (0 === \strpos($id, 'monolog.logger.')) {
+                $channels[] = \substr($id, 15);
+            }
+        }
+
+        return $channels;
     }
 }

--- a/DependencyInjection/EkinoNewRelicExtension.php
+++ b/DependencyInjection/EkinoNewRelicExtension.php
@@ -125,7 +125,7 @@ class EkinoNewRelicExtension extends Extension
                 throw new \LogicException('The "symfony/monolog-bundle" package must be installed in order to use "monolog" option.');
             }
             $loader->load('monolog.xml');
-            $container->setParameter('ekino.new_relic.monolog.channels', $config['monolog']['channels']);
+            $container->setParameter('ekino.new_relic.monolog.channels', $config['monolog']['channels'] ?? null);
             $container->setAlias('ekino.new_relic.logs_handler', $config['monolog']['service'])->setPublic(false);
 
             $level = $config['monolog']['level'];

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ ekino_new_relic:
         ignored_paths: []                 # No transaction recorded for this paths
     monolog: 
         enabled: false                    # When enabled, send application's logs to New Relic (default: disabled)
-        channels: [app]                   # Channels to listen (default: app)
+        channels: [app]                   # Channels to listen (default: null). [See Symfony's documentation](http://symfony.com/doc/current/logging/channels_handlers.html#yaml-specification)
         level: error                      # Report only logs higher than this level (see \Psr\Log\LogLevel) (default: error)
         service: app.my_custom_handler    # Define a custom log handler (default: ekino.new_relic.monolog_handler)
     commands: 

--- a/Tests/DependencyInjection/Compiler/MonologHandlerPassTest.php
+++ b/Tests/DependencyInjection/Compiler/MonologHandlerPassTest.php
@@ -27,13 +27,36 @@ class MonologHandlerPassTest extends AbstractCompilerPassTestCase
 
     public function testProcessChannel()
     {
-        $this->container->setParameter('ekino.new_relic.monolog.channels', ['app', 'foo']);
-        $this->registerService('monolog.logger', \Monolog\Logger::class);
-        $this->registerService('monolog.logger.foo', \Monolog\Logger::class);
+        $this->container->setParameter('ekino.new_relic.monolog.channels', ['type' => 'inclusive', 'elements' => ['app', 'foo']]);
+        $this->registerService('monolog.logger', \Monolog\Logger::class)->setArgument(0, 'app');
+        $this->registerService('monolog.logger.foo', \Monolog\Logger::class)->setArgument(0, 'foo');
 
         $this->compile();
 
         $this->assertContainerBuilderHasServiceDefinitionWithMethodCall('monolog.logger', 'pushHandler', [new Reference('ekino.new_relic.logs_handler')]);
         $this->assertContainerBuilderHasServiceDefinitionWithMethodCall('monolog.logger.foo', 'pushHandler', [new Reference('ekino.new_relic.logs_handler')]);
+    }
+
+    public function testProcessChannelAllChannels()
+    {
+        $this->container->setParameter('ekino.new_relic.monolog.channels', null);
+        $this->registerService('monolog.logger', \Monolog\Logger::class)->setArgument(0, 'app');
+        $this->registerService('monolog.logger.foo', \Monolog\Logger::class)->setArgument(0, 'foo');
+
+        $this->compile();
+
+        $this->assertContainerBuilderHasServiceDefinitionWithMethodCall('monolog.logger', 'pushHandler', [new Reference('ekino.new_relic.logs_handler')]);
+        $this->assertContainerBuilderHasServiceDefinitionWithMethodCall('monolog.logger.foo', 'pushHandler', [new Reference('ekino.new_relic.logs_handler')]);
+    }
+
+    public function testProcessChannelExcludeChannels()
+    {
+        $this->container->setParameter('ekino.new_relic.monolog.channels', ['type' => 'exclusive', 'elements' => ['foo']]);
+        $this->registerService('monolog.logger', \Monolog\Logger::class)->setArgument(0, 'app');
+        $this->registerService('monolog.logger.foo', \Monolog\Logger::class)->setArgument(0, 'foo');
+
+        $this->compile();
+
+        $this->assertContainerBuilderHasServiceDefinitionWithMethodCall('monolog.logger', 'pushHandler', [new Reference('ekino.new_relic.logs_handler')]);
     }
 }


### PR DESCRIPTION
Allows a configuration similar to the MonologBUndle's one (http://symfony.com/doc/current/logging/channels_handlers.html#yaml-specification)

```
channels: ~    # Include all the channels  
channels: foo  # Include only channel 'foo' 
channels: '!foo' # Include all channels, except 'foo' 
channels: [foo, bar]   # Include only channels 'foo' and 'bar' 
channels: ['!foo', '!bar'] # Include all channels, except 'foo' and 'bar'
```

Most of the code come from the MonologBundle itself (https://github.com/symfony/monolog-bundle/tree/master/DependencyInjection)