### PR TITLE
Make sure we always return true

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Fixed type error when no Content-Type header was returned.
+- Make sure `NewRelicInteractor::disableAutoRUM` always returns true. 
 
 ## v2.0.0-beta4
 

--- a/NewRelic/NewRelicInteractor.php
+++ b/NewRelic/NewRelicInteractor.php
@@ -57,7 +57,9 @@ class NewRelicInteractor implements NewRelicInteractorInterface
 
     public function disableAutoRUM(): bool
     {
-        return newrelic_disable_autorum();
+        newrelic_disable_autorum();
+
+        return true;
     }
 
     public function noticeError(int $errno, string $errstr, string $errfile = null, int $errline = null, string $errcontext = null): void


### PR DESCRIPTION
I run the latest new relic extension that I can install with Yum. And I get the following error:

> Type error: Return value of Ekino\NewRelicBundle\NewRelic\NewRelicInteractor::disableAutoRUM() must be of the type boolean, null returned

According to the [docs](https://docs.newrelic.com/docs/agents/php-agent/php-agent-api/newrelic_disable_autorum) it should always return true... But that is not the case. I will contact the support about this. 

However, This is a fix that make sure it always works. It looks weird but it is according to the current new relic docs. 
