### PR TITLE
Update interface return value to match the new NewRelic API

### DIFF
--- a/NewRelic/AdaptiveInteractor.php
+++ b/NewRelic/AdaptiveInteractor.php
@@ -70,7 +70,7 @@ class AdaptiveInteractor implements NewRelicInteractorInterface
         return $this->interactor->getBrowserTimingFooter($includeTags);
     }
 
-    public function disableAutoRUM(): bool
+    public function disableAutoRUM(): ?bool
     {
         return $this->interactor->disableAutoRUM();
     }

--- a/NewRelic/BlackholeInteractor.php
+++ b/NewRelic/BlackholeInteractor.php
@@ -58,7 +58,7 @@ class BlackholeInteractor implements NewRelicInteractorInterface
         return '';
     }
 
-    public function disableAutoRUM(): bool
+    public function disableAutoRUM(): ?bool
     {
         return true;
     }

--- a/NewRelic/LoggingInteractorDecorator.php
+++ b/NewRelic/LoggingInteractorDecorator.php
@@ -81,7 +81,7 @@ class LoggingInteractorDecorator implements NewRelicInteractorInterface
         return $this->interactor->getBrowserTimingFooter($includeTags);
     }
 
-    public function disableAutoRUM(): bool
+    public function disableAutoRUM(): ?bool
     {
         $this->logger->debug('Disabling New Relic Auto-RUM');
 

--- a/NewRelic/NewRelicInteractor.php
+++ b/NewRelic/NewRelicInteractor.php
@@ -55,11 +55,9 @@ class NewRelicInteractor implements NewRelicInteractorInterface
         return newrelic_get_browser_timing_footer($includeTags);
     }
 
-    public function disableAutoRUM(): bool
+    public function disableAutoRUM(): ?bool
     {
-        newrelic_disable_autorum();
-
-        return true;
+        return newrelic_disable_autorum();
     }
 
     public function noticeError(int $errno, string $errstr, string $errfile = null, int $errline = null, string $errcontext = null): void

--- a/NewRelic/NewRelicInteractorInterface.php
+++ b/NewRelic/NewRelicInteractorInterface.php
@@ -79,7 +79,7 @@ interface NewRelicInteractorInterface
      *
      * {@link https://docs.newrelic.com/docs/agents/php-agent/php-agent-api/newrelic_disable_autorum}
      */
-    public function disableAutoRUM(): bool;
+    public function disableAutoRUM(): ?bool;
 
     /**
      * Use these calls to collect errors that the PHP agent does not collect automatically and to set the callback for


### PR DESCRIPTION
This is a follow-up form https://github.com/ekino/EkinoNewRelicBundle/pull/193,

NewRelic updated their API after I made this comment: https://discuss.newrelic.com/t/php-newrelic-disable-autorum-does-not-return-boolean/57148

