### PR TITLE
Fix monolog external service

### DIFF
--- a/DependencyInjection/EkinoNewRelicExtension.php
+++ b/DependencyInjection/EkinoNewRelicExtension.php
@@ -125,18 +125,9 @@ class EkinoNewRelicExtension extends Extension
                 throw new \LogicException('The "symfony/monolog-bundle" package must be installed in order to use "monolog" option.');
             }
             $loader->load('monolog.xml');
-            $container->setParameter('ekino.new_relic.monolog.channels', $config['monolog']['channels'] ?? null);
+            $container->setParameter('ekino.new_relic.monolog', $config['monolog'] ?? []);
+            $container->setParameter('ekino.new_relic.application_name', $config['application_name']);
             $container->setAlias('ekino.new_relic.logs_handler', $config['monolog']['service'])->setPublic(false);
-
-            $level = $config['monolog']['level'];
-            // This service is used by MonologHandlerPass to inject into Monolog Service
-            $container->findDefinition('ekino.new_relic.logs_handler')
-                ->setArguments(
-                    [
-                        '$level' => \is_int($level) ? $level : \constant('Monolog\Logger::'.\strtoupper($level)),
-                        '$appName' => $config['application_name'],
-                    ]
-                );
         }
     }
 

--- a/Tests/DependencyInjection/Compiler/MonologHandlerPassTest.php
+++ b/Tests/DependencyInjection/Compiler/MonologHandlerPassTest.php
@@ -27,7 +27,10 @@ class MonologHandlerPassTest extends AbstractCompilerPassTestCase
 
     public function testProcessChannel()
     {
-        $this->container->setParameter('ekino.new_relic.monolog.channels', ['type' => 'inclusive', 'elements' => ['app', 'foo']]);
+        $this->container->setParameter('ekino.new_relic.monolog', ['level' => 100, 'channels' => ['type' => 'inclusive', 'elements' => ['app', 'foo']]]);
+        $this->container->setParameter('ekino.new_relic.application_name', 'app');
+        $this->registerService('ekino.new_relic.monolog_handler', \Monolog\Handler\NewRelicHandler::class);
+        $this->container->setAlias('ekino.new_relic.logs_handler', 'ekino.new_relic.monolog_handler')->setPublic(false);
         $this->registerService('monolog.logger', \Monolog\Logger::class)->setArgument(0, 'app');
         $this->registerService('monolog.logger.foo', \Monolog\Logger::class)->setArgument(0, 'foo');
 
@@ -39,7 +42,10 @@ class MonologHandlerPassTest extends AbstractCompilerPassTestCase
 
     public function testProcessChannelAllChannels()
     {
-        $this->container->setParameter('ekino.new_relic.monolog.channels', null);
+        $this->container->setParameter('ekino.new_relic.monolog', ['level' => 100, 'channels' => null]);
+        $this->container->setParameter('ekino.new_relic.application_name', 'app');
+        $this->registerService('ekino.new_relic.monolog_handler', \Monolog\Handler\NewRelicHandler::class);
+        $this->container->setAlias('ekino.new_relic.logs_handler', 'ekino.new_relic.monolog_handler')->setPublic(false);
         $this->registerService('monolog.logger', \Monolog\Logger::class)->setArgument(0, 'app');
         $this->registerService('monolog.logger.foo', \Monolog\Logger::class)->setArgument(0, 'foo');
 
@@ -51,7 +57,10 @@ class MonologHandlerPassTest extends AbstractCompilerPassTestCase
 
     public function testProcessChannelExcludeChannels()
     {
-        $this->container->setParameter('ekino.new_relic.monolog.channels', ['type' => 'exclusive', 'elements' => ['foo']]);
+        $this->container->setParameter('ekino.new_relic.monolog', ['level' => 100, 'channels' => ['type' => 'exclusive', 'elements' => ['foo']]]);
+        $this->container->setParameter('ekino.new_relic.application_name', 'app');
+        $this->registerService('ekino.new_relic.monolog_handler', \Monolog\Handler\NewRelicHandler::class);
+        $this->container->setAlias('ekino.new_relic.logs_handler', 'ekino.new_relic.monolog_handler')->setPublic(false);
         $this->registerService('monolog.logger', \Monolog\Logger::class)->setArgument(0, 'app');
         $this->registerService('monolog.logger.foo', \Monolog\Logger::class)->setArgument(0, 'foo');
 

--- a/Tests/DependencyInjection/EkinoNewRelicExtensionTest.php
+++ b/Tests/DependencyInjection/EkinoNewRelicExtensionTest.php
@@ -71,9 +71,9 @@ class EkinoNewRelicExtensionTest extends AbstractExtensionTestCase
     {
         $this->load(['monolog' => true]);
 
-        $this->assertContainerBuilderHasParameter('ekino.new_relic.monolog.channels');
+        $this->assertContainerBuilderHasParameter('ekino.new_relic.monolog');
+        $this->assertContainerBuilderHasParameter('ekino.new_relic.application_name');
         $this->assertContainerBuilderHasService('ekino.new_relic.logs_handler');
-        $this->assertContainerBuilderHasServiceDefinitionWithArgument('ekino.new_relic.logs_handler', '$level', 400);
     }
 
     public function testMonologDisabled()
@@ -82,7 +82,7 @@ class EkinoNewRelicExtensionTest extends AbstractExtensionTestCase
 
         self::assertThat(
             $this->container,
-            new LogicalNot(new ContainerHasParameterConstraint('ekino.new_relic.monolog.channels', null, false))
+            new LogicalNot(new ContainerHasParameterConstraint('ekino.new_relic.monolog', null, false))
         );
     }
 


### PR DESCRIPTION
Move the service configuration from Extension to CompilerPass as the extension is only able to see it own services/alias and is not able to see the application's one