### PR TITLE
Remove ExceptionListener when `enabled: false`

### DIFF
--- a/DependencyInjection/EkinoNewRelicExtension.php
+++ b/DependencyInjection/EkinoNewRelicExtension.php
@@ -129,6 +129,10 @@ class EkinoNewRelicExtension extends Extension
             $container->setParameter('ekino.new_relic.application_name', $config['application_name']);
             $container->setAlias('ekino.new_relic.logs_handler', $config['monolog']['service'])->setPublic(false);
         }
+
+        if (!$config['enabled']) {
+            $container->removeDefinition(ExceptionListener::class);
+        }
     }
 
     private function getInteractorServiceId(array $config): string


### PR DESCRIPTION
I don't want the ExceptionListener to be active in `test` environment, because sometimes they are fighting with each other:
```
/vagrant/vendor/sentry/sentry/lib/Raven/Breadcrumbs/ErrorHandler.php:34
/vagrant/vendor/sentry/sentry/lib/Raven/ErrorHandler.php:127
/vagrant/vendor/ekino/newrelic-bundle/Listener/DeprecationListener.php:41
/vagrant/vendor/sentry/sentry/lib/Raven/Breadcrumbs/ErrorHandler.php:34
/vagrant/vendor/sentry/sentry/lib/Raven/ErrorHandler.php:127
/vagrant/vendor/ekino/newrelic-bundle/Listener/DeprecationListener.php:41
/vagrant/vendor/sentry/sentry/lib/Raven/Breadcrumbs/ErrorHandler.php:34
/vagrant/vendor/sentry/sentry/lib/Raven/ErrorHandler.php:127
/vagrant/vendor/ekino/newrelic-bundle/Listener/DeprecationListener.php:41
/vagrant/vendor/sentry/sentry/lib/Raven/Breadcrumbs/ErrorHandler.php:34
/vagrant/vendor/sentry/sentry/lib/Raven/ErrorHandler.php:127
/vagrant/vendor/ekino/newrelic-bundle/Listener/DeprecationListener.php:41
/vagrant/vendor/sentry/sentry/lib/Raven/Breadcrumbs/ErrorHandler.php:34
/vagrant/vendor/sentry/sentry/lib/Raven/ErrorHandler.php:127
/vagrant/vendor/ekino/newrelic-bundle/Listener/DeprecationListener.php:41
/vagrant/vendor/sentry/sentry/lib/Raven/Breadcrumbs/ErrorHandler.php:34
/vagrant/vendor/sentry/sentry/lib/Raven/ErrorHandler.php:127
/vagrant/vendor/ekino/newrelic-bundle/Listener/DeprecationListener.php:41
/vagrant/vendor/sentry/sentry/lib/Raven/Breadcrumbs/ErrorHandler.php:34
/vagrant/vendor/sentry/sentry/lib/Raven/ErrorHandler.php:127
/vagrant/vendor/ekino/newrelic-bundle/Listener/DeprecationListener.php:41
/vagrant/vendor/sentry/sentry/lib/Raven/Breadcrumbs/ErrorHandler.php:34
/vagrant/vendor/sentry/sentry/lib/Raven/ErrorHandler.php:127
/vagrant/vendor/ekino/newrelic-bundle/Listener/DeprecationListener.php:41
/vagrant/vendor/sentry/sentry/lib/Raven/Breadcrumbs/ErrorHandler.php:34
/vagrant/vendor/sentry/sentry/lib/Raven/ErrorHandler.php:127
/vagrant/vendor/ekino/newrelic-bundle/Listener/DeprecationListener.php:41
/vagrant/vendor/sentry/sentry/lib/Raven/Breadcrumbs/ErrorHandler.php:34
/vagrant/vendor/sentry/sentry/lib/Raven/ErrorHandler.php:127
/vagrant/vendor/ekino/newrelic-bundle/Listener/DeprecationListener.php:41
/vagrant/vendor/sentry/sentry/lib/Raven/Breadcrumbs/ErrorHandler.php:34
/vagrant/vendor/sentry/sentry/lib/Raven/ErrorHandler.php:127
/vagrant/vendor/ekino/newrelic-bundle/Listener/DeprecationListener.php:41
/vagrant/vendor/sentry/sentry/lib/Raven/Breadcrumbs/ErrorHandler.php:34
/vagrant/vendor/sentry/sentry/lib/Raven/ErrorHandler.php:127
/vagrant/vendor/ekino/newrelic-bundle/Listener/DeprecationListener.php:41
/vagrant/vendor/sentry/sentry/lib/Raven/Breadcrumbs/ErrorHandler.php:34
/vagrant/vendor/sentry/sentry/lib/Raven/ErrorHandler.php:127
/vagrant/vendor/ekino/newrelic-bundle/Listener/DeprecationListener.php:41
/vagrant/vendor/sentry/sentry/lib/Raven/Breadcrumbs/ErrorHandler.php:34
/vagrant/vendor/sentry/sentry/lib/Raven/ErrorHandler.php:127
/vagrant/vendor/ekino/newrelic-bundle/Listener/DeprecationListener.php:41
/vagrant/vendor/sentry/sentry/lib/Raven/Breadcrumbs/ErrorHandler.php:34
/vagrant/vendor/sentry/sentry/lib/Raven/ErrorHandler.php:127
/vagrant/vendor/ekino/newrelic-bundle/Listener/DeprecationListener.php:41
/vagrant/vendor/sentry/sentry/lib/Raven/Breadcrumbs/ErrorHandler.php:34
/vagrant/vendor/sentry/sentry/lib/Raven/ErrorHandler.php:127
/vagrant/vendor/ekino/newrelic-bundle/Listener/DeprecationListener.php:41
/vagrant/vendor/sentry/sentry/lib/Raven/Breadcrumbs/ErrorHandler.php:34
/vagrant/vendor/sentry/sentry/lib/Raven/ErrorHandler.php:127
/vagrant/vendor/ekino/newrelic-bundle/Listener/DeprecationListener.php:41
```