### PR TITLE
Unregister DeprecationHandler on Kernel termination

### DIFF
--- a/Listener/DeprecationListener.php
+++ b/Listener/DeprecationListener.php
@@ -31,6 +31,7 @@ class DeprecationListener
         if ($this->isRegistered) {
             return;
         }
+
         $this->isRegistered = true;
 
         $prevErrorHandler = \set_error_handler(function ($type, $msg, $file, $line, $context = []) use (&$prevErrorHandler) {
@@ -47,6 +48,7 @@ class DeprecationListener
         if (!$this->isRegistered) {
             return;
         }
+
         $this->isRegistered = false;
         \restore_error_handler();
     }

--- a/Resources/config/deprecation_listener.xml
+++ b/Resources/config/deprecation_listener.xml
@@ -7,6 +7,8 @@
     <services>
         <defaults autowire="true" autoconfigure="true" public="false" />
 
-        <service id="Ekino\NewRelicBundle\Listener\DeprecationListener" public="true" />
+        <service id="Ekino\NewRelicBundle\Listener\DeprecationListener" public="true">
+            <tag name="kernel.event_listener" event="kernel.terminate" method="unregister" />
+        </service>
     </services>
 </container>


### PR DESCRIPTION
Replaces https://github.com/ekino/EkinoNewRelicBundle/pull/209 because `shutdown` on bundle is not called on `$kernel->terminate()`. 

It's only called when you call `$kernel->reboot()`

Replaces #208