### PR TITLE
Extra check for the newrelic extension

### DIFF
--- a/DependencyInjection/EkinoNewRelicExtension.php
+++ b/DependencyInjection/EkinoNewRelicExtension.php
@@ -120,7 +120,7 @@ class EkinoNewRelicExtension extends Extension
             $loader->load('twig.xml');
         }
 
-        if ($config['enabled'] && $config['monolog']['enabled']) {
+        if (\extension_loaded('newrelic') && $config['enabled'] && $config['monolog']['enabled']) {
             if (!\class_exists(\Monolog\Handler\NewRelicHandler::class)) {
                 throw new \LogicException('The "symfony/monolog-bundle" package must be installed in order to use "monolog" option.');
             }


### PR DESCRIPTION
I've discovered that I cannot have `monolog.enabled = true` without the newrelic extension installed because monolog's NewRelicHandler will throw a `MissingExtensionException`.

Is there a better way of achieving this?

Locally this means I can use the same yaml file from a machine with the extension installed and not see the above exception