### PR TITLE
Fix left-associative ternary deprecation warnings for PHP 7.4

### DIFF
--- a/NewRelic/Config.php
+++ b/NewRelic/Config.php
@@ -29,9 +29,9 @@ class Config
 
     public function __construct(?string $name, string $apiKey = null, string $licenseKey = null, bool $xmit = false, array $deploymentNames = [])
     {
-        $this->name = !empty($name) ? $name : \ini_get('newrelic.appname') ?: '';
+        $this->name = (!empty($name) ? $name : \ini_get('newrelic.appname')) ?: '';
         $this->apiKey = $apiKey;
-        $this->licenseKey = !empty($licenseKey) ? $licenseKey : \ini_get('newrelic.license') ?: '';
+        $this->licenseKey = (!empty($licenseKey) ? $licenseKey : \ini_get('newrelic.license')) ?: '';
         $this->xmit = $xmit;
         $this->deploymentNames = $deploymentNames;
         $this->customEvents = [];


### PR DESCRIPTION
PHP is deprecating chaining ternary operators for PHP 7.4, and will throw an error in PHP 8+ ([see this RFC](https://wiki.php.net/rfc/ternary_associativity)).

As shown in [this gist](https://gist.github.com/nikic/b6214f87b0e4a7c6fe26919ac849194f) searching for possible issues in the top 1000 Packagist repos, `EkinoNewRelicBundle` has two occurences of this syntax. I added parenthesis as recommended in the RFC to avoid any warning and future errors.