### PR TITLE
Fix twig-related deprecation errors

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -17,6 +17,7 @@ use Psr\Log\LogLevel;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
 use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
+use Twig\Environment;
 
 class Configuration implements ConfigurationInterface
 {
@@ -34,7 +35,7 @@ class Configuration implements ConfigurationInterface
             ->children()
                 ->booleanNode('enabled')->defaultTrue()->end()
                 ->scalarNode('interactor')->end()
-                ->booleanNode('twig')->defaultValue(\class_exists('\Twig_Environment'))->end()
+                ->booleanNode('twig')->defaultValue(\class_exists(Environment::class))->end()
                 ->scalarNode('api_key')->defaultValue(null)->end()
                 ->scalarNode('license_key')->defaultValue(null)->end()
                 ->scalarNode('application_name')->defaultValue(null)->end()

--- a/Twig/NewRelicExtension.php
+++ b/Twig/NewRelicExtension.php
@@ -15,11 +15,13 @@ namespace Ekino\NewRelicBundle\Twig;
 
 use Ekino\NewRelicBundle\NewRelic\Config;
 use Ekino\NewRelicBundle\NewRelic\NewRelicInteractorInterface;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFunction;
 
 /**
  * Twig extension to manually include BrowserTimingHeader and BrowserTimingFooter into twig templates.
  */
-class NewRelicExtension extends \Twig_Extension
+class NewRelicExtension extends AbstractExtension
 {
     private $newRelic;
     private $interactor;
@@ -43,8 +45,8 @@ class NewRelicExtension extends \Twig_Extension
     public function getFunctions(): array
     {
         return [
-            new \Twig_SimpleFunction('ekino_newrelic_browser_timing_header', [$this, 'getNewrelicBrowserTimingHeader'], ['is_safe' => ['html']]),
-            new \Twig_SimpleFunction('ekino_newrelic_browser_timing_footer', [$this, 'getNewrelicBrowserTimingFooter'], ['is_safe' => ['html']]),
+            new TwigFunction('ekino_newrelic_browser_timing_header', [$this, 'getNewrelicBrowserTimingHeader'], ['is_safe' => ['html']]),
+            new TwigFunction('ekino_newrelic_browser_timing_footer', [$this, 'getNewrelicBrowserTimingFooter'], ['is_safe' => ['html']]),
         ];
     }
 


### PR DESCRIPTION
Closes #217

Some Twig classes are deprecated thus we have to stop using them, such as:

- `\Twig_Environment`
- `\Twig_Extension`
- `\TwigFilter`

This PR also causes adds `phpunit/phpunit` ^7.5 as an explicit dev dependency, since people might use a global phpunit ^8 dependency and this version is incompatible with the tests (but fixing the tests themselves would be out of the scope of this PR).