### PR TITLE
Require phpunit/phpunit 7.5 in dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,8 @@
         "symfony/phpunit-bridge": "^4.0",
         "twig/twig": "^1.32 || ^2.4",
         "symfony/monolog-bundle": "^3.2",
-        "friendsofphp/php-cs-fixer": "^2.11"
+        "friendsofphp/php-cs-fixer": "^2.11",
+        "phpunit/phpunit": "^7.5"
     },
     "conflict": {
         "twig/twig": "<1.32"

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -8,7 +8,6 @@
          convertWarningsToExceptions="true"
          processIsolation="false"
          stopOnFailure="false"
-         syntaxCheck="false"
          bootstrap="vendor/autoload.php"
 >
     <testsuites>


### PR DESCRIPTION
There's no explicit dependency on phpunit/phpunit and version ^8.2 causes a PHP error, so we have to require ^7.5 instead.