### PR TITLE
Fix deprecation: Use `getThrowable` when possible

### DIFF
--- a/Listener/ExceptionListener.php
+++ b/Listener/ExceptionListener.php
@@ -40,9 +40,14 @@ class ExceptionListener implements EventSubscriberInterface
 
     public function onKernelException(GetResponseForExceptionEvent $event): void
     {
-        $exception = $event->getException();
-        if (!$exception instanceof HttpExceptionInterface) {
-            $this->interactor->noticeThrowable($exception);
+        if (method_exists($event, 'getThrowable')) {
+            $throwable = $event->getThrowable();
+        } else {
+            $throwable = $event->getException();
+        }
+
+        if (!$throwable instanceof HttpExceptionInterface) {
+            $this->interactor->noticeThrowable($throwable);
         }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/ekino/EkinoNewRelicBundle/issues/237