### PR TITLE
Fix compatibility issue with symfony 5.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ env:
     global:
         - PHPUNIT_FLAGS="-v"
         - SYMFONY_PHPUNIT_DIR="$HOME/symfony-bridge/.phpunit"
-        - SYMFONY_PHPUNIT_VERSION="6.5"
 
 matrix:
     fast_finish: true
@@ -29,9 +28,11 @@ matrix:
           # Test LTS versions. This makes sure we do not use Symfony packages with version greater
           # than 2 or 3 respectively. Read more at https://github.com/symfony/lts
         - php: 7.3
-          env: DEPENDENCIES="dunglas/symfony-lock:^3"
+          env: SYMFONY_REQUIRE="^3.0"
         - php: 7.3
-          env: DEPENDENCIES="dunglas/symfony-lock:^4"
+          env: SYMFONY_REQUIRE="^4.0"
+        - php: 7.3
+          env: SYMFONY_REQUIRE="^5.0"
 
           # Latest commit to master
         - php: 7.3
@@ -44,11 +45,9 @@ matrix:
 before_install:
     - if [[ $COVERAGE != true ]]; then phpenv config-rm xdebug.ini || true; fi
     - if ! [ -z "$STABILITY" ]; then composer config minimum-stability ${STABILITY}; fi;
-    - if ! [ -v "$DEPENDENCIES" ]; then composer require --no-update ${DEPENDENCIES}; fi;
+    - if ! [ -v "$SYMFONY_REQUIRE" ]; then composer global require symfony/flex; fi;
 
 install:
-    # To be removed when this issue will be resolved: https://github.com/composer/composer/issues/5355
-    - if [[ "$COMPOSER_FLAGS" == *"--prefer-lowest"* ]]; then composer update --prefer-dist --no-interaction --prefer-stable --quiet; fi
     - composer update ${COMPOSER_FLAGS} --prefer-dist --no-interaction
     - ./vendor/bin/simple-phpunit install
 

--- a/Listener/RequestListener.php
+++ b/Listener/RequestListener.php
@@ -17,8 +17,8 @@ use Ekino\NewRelicBundle\NewRelic\Config;
 use Ekino\NewRelicBundle\NewRelic\NewRelicInteractorInterface;
 use Ekino\NewRelicBundle\TransactionNamingStrategy\TransactionNamingStrategyInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
-use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
+use Symfony\Component\HttpKernel\Event\ResponseEvent;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\HttpKernel\KernelEvents;
 
@@ -58,8 +58,15 @@ class RequestListener implements EventSubscriberInterface
         ];
     }
 
-    public function setApplicationName(GetResponseEvent $event): void
+    /**
+     * @param GetResponseEvent|ResponseEvent $event
+     */
+    public function setApplicationName($event): void
     {
+        if (!$event instanceof GetResponseEvent && !$event instanceof ResponseEvent) {
+            throw new \InvalidArgumentException(\sprintf('Expected instance of type %s, %s given', \class_exists(ResponseEvent::class) ? ResponseEvent::class : GetResponseEvent::class, \is_object($event) ? \get_class($event) : \gettype($event)));
+        }
+
         if (!$this->isEventValid($event)) {
             return;
         }
@@ -80,8 +87,15 @@ class RequestListener implements EventSubscriberInterface
         }
     }
 
-    public function setTransactionName(GetResponseEvent $event): void
+    /**
+     * @param GetResponseEvent|ResponseEvent $event
+     */
+    public function setTransactionName($event): void
     {
+        if (!$event instanceof GetResponseEvent && !$event instanceof ResponseEvent) {
+            throw new \InvalidArgumentException(\sprintf('Expected instance of type %s, %s given', \class_exists(ResponseEvent::class) ? ResponseEvent::class : GetResponseEvent::class, \is_object($event) ? \get_class($event) : \gettype($event)));
+        }
+
         if (!$this->isEventValid($event)) {
             return;
         }
@@ -91,8 +105,15 @@ class RequestListener implements EventSubscriberInterface
         $this->interactor->setTransactionName($transactionName);
     }
 
-    public function setIgnoreTransaction(GetResponseEvent $event): void
+    /**
+     * @param GetResponseEvent|ResponseEvent $event
+     */
+    public function setIgnoreTransaction($event): void
     {
+        if (!$event instanceof GetResponseEvent && !$event instanceof ResponseEvent) {
+            throw new \InvalidArgumentException(\sprintf('Expected instance of type %s, %s given', \class_exists(ResponseEvent::class) ? ResponseEvent::class : GetResponseEvent::class, \is_object($event) ? \get_class($event) : \gettype($event)));
+        }
+
         if (!$this->isEventValid($event)) {
             return;
         }
@@ -109,9 +130,15 @@ class RequestListener implements EventSubscriberInterface
 
     /**
      * Make sure we should consider this event. Example: make sure it is a master request.
+     *
+     * @param GetResponseEvent|ResponseEvent $event
      */
-    private function isEventValid(GetResponseEvent $event): bool
+    private function isEventValid($event): bool
     {
+        if (!$event instanceof GetResponseEvent && !$event instanceof ResponseEvent) {
+            throw new \InvalidArgumentException(\sprintf('Expected instance of type %s, %s given', \class_exists(ResponseEvent::class) ? ResponseEvent::class : GetResponseEvent::class, \is_object($event) ? \get_class($event) : \gettype($event)));
+        }
+
         return HttpKernelInterface::MASTER_REQUEST === $event->getRequestType();
     }
 }

--- a/Listener/ResponseListener.php
+++ b/Listener/ResponseListener.php
@@ -19,6 +19,7 @@ use Ekino\NewRelicBundle\Twig\NewRelicExtension;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
+use Symfony\Component\HttpKernel\Event\ResponseEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
 
 class ResponseListener implements EventSubscriberInterface
@@ -52,8 +53,15 @@ class ResponseListener implements EventSubscriberInterface
         ];
     }
 
-    public function onKernelResponse(FilterResponseEvent $event): void
+    /**
+     * @param FilterResponseEvent|ResponseEvent $event
+     */
+    public function onKernelResponse($event): void
     {
+        if (!$event instanceof FilterResponseEvent && !$event instanceof ResponseEvent) {
+            throw new \InvalidArgumentException(\sprintf('Expected instance of type %s, %s given', \class_exists(ResponseEvent::class) ? ResponseEvent::class : FilterResponseEvent::class, \is_object($event) ? \get_class($event) : \gettype($event)));
+        }
+
         if (!$event->isMasterRequest()) {
             return;
         }

--- a/Tests/BundleInitializationTest.php
+++ b/Tests/BundleInitializationTest.php
@@ -28,7 +28,7 @@ use Nyholm\BundleTest\CompilerPass\PublicServicePass;
  */
 class BundleInitializationTest extends BaseBundleTestCase
 {
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/Tests/DependencyInjection/Compiler/MonologHandlerPassTest.php
+++ b/Tests/DependencyInjection/Compiler/MonologHandlerPassTest.php
@@ -20,7 +20,7 @@ use Symfony\Component\DependencyInjection\Reference;
 
 class MonologHandlerPassTest extends AbstractCompilerPassTestCase
 {
-    protected function registerCompilerPass(ContainerBuilder $container)
+    protected function registerCompilerPass(ContainerBuilder $container): void
     {
         $container->addCompilerPass(new MonologHandlerPass());
     }

--- a/Tests/DependencyInjection/ConfigurationTest.php
+++ b/Tests/DependencyInjection/ConfigurationTest.php
@@ -84,13 +84,13 @@ class ConfigurationTest extends TestCase
         $config = $processor->processConfiguration(new Configuration(), []);
 
         $this->assertEmpty($config['http']['ignored_routes']);
-        $this->assertInternalType('array', $config['http']['ignored_routes']);
+        $this->assertIsArray($config['http']['ignored_routes']);
         $this->assertEmpty($config['http']['ignored_paths']);
-        $this->assertInternalType('array', $config['http']['ignored_paths']);
+        $this->assertIsArray($config['http']['ignored_paths']);
         $this->assertEmpty($config['commands']['ignored_commands']);
-        $this->assertInternalType('array', $config['commands']['ignored_commands']);
+        $this->assertIsArray($config['commands']['ignored_commands']);
         $this->assertEmpty($config['deployment_names']);
-        $this->assertInternalType('array', $config['deployment_names']);
+        $this->assertIsArray($config['deployment_names']);
     }
 
     public static function ignoredRoutesProvider()

--- a/Tests/DependencyInjection/EkinoNewRelicExtensionTest.php
+++ b/Tests/DependencyInjection/EkinoNewRelicExtensionTest.php
@@ -26,12 +26,12 @@ use PHPUnit\Framework\Constraint\LogicalNot;
 
 class EkinoNewRelicExtensionTest extends AbstractExtensionTestCase
 {
-    protected function getContainerExtensions()
+    protected function getContainerExtensions(): array
     {
         return [new EkinoNewRelicExtension()];
     }
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/Tests/Listener/DeprecationListenerTest.php
+++ b/Tests/Listener/DeprecationListenerTest.php
@@ -23,7 +23,9 @@ class DeprecationListenerTest extends TestCase
     public function testDeprecationIsReported()
     {
         $interactor = $this->getMockBuilder(NewRelicInteractorInterface::class)->getMock();
-        $interactor->expects($this->once())->method('noticeThrowable')->with($this->isInstanceOf(DeprecationException::class));
+        $interactor->expects($this->once())->method('noticeThrowable')->with(
+            $this->isInstanceOf(DeprecationException::class)
+        );
 
         $listener = new DeprecationListener($interactor);
 
@@ -78,7 +80,7 @@ class DeprecationListenerTest extends TestCase
         $interactor = $this->getMockBuilder(NewRelicInteractorInterface::class)->getMock();
         $interactor->expects($this->once())->method('noticeThrowable');
 
-        $handler = $this->createPartialMock(\stdClass::class, ['__invoke']);
+        $handler = $this->createPartialMock(DummyHandler::class, ['__invoke']);
         $handler->expects($this->once())->method('__invoke');
 
         $listener = new DeprecationListener($interactor);
@@ -114,7 +116,7 @@ class DeprecationListenerTest extends TestCase
     {
         $interactor = $this->getMockBuilder(NewRelicInteractorInterface::class)->getMock();
 
-        $handler = $this->createPartialMock(\stdClass::class, ['__invoke']);
+        $handler = $this->createPartialMock(DummyHandler::class, ['__invoke']);
         $handler->expects($this->once())->method('__invoke');
 
         $listener = new DeprecationListener($interactor);
@@ -127,5 +129,12 @@ class DeprecationListenerTest extends TestCase
         } finally {
             \restore_error_handler();
         }
+    }
+}
+
+class DummyHandler
+{
+    public function __invoke()
+    {
     }
 }

--- a/Tests/Listener/ExceptionListenerTest.php
+++ b/Tests/Listener/ExceptionListenerTest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Ekino New Relic bundle.
+ *
+ * (c) Ekino - Thomas Rabaix <thomas.rabaix@ekino.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Ekino\NewRelicBundle\Tests\Listener;
+
+use Ekino\NewRelicBundle\Listener\ExceptionListener;
+use Ekino\NewRelicBundle\NewRelic\NewRelicInteractorInterface;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Event\ExceptionEvent;
+use Symfony\Component\HttpKernel\Event\GetResponseForExceptionEvent;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+
+class ExceptionListenerTest extends TestCase
+{
+    public function testOnKernelException()
+    {
+        $exception = new \Exception('Boom');
+
+        $interactor = $this->getMockBuilder(NewRelicInteractorInterface::class)->getMock();
+        $interactor->expects($this->once())->method('noticeThrowable')->with($exception);
+
+        $kernel = $this->getMockBuilder(HttpKernelInterface::class)->getMock();
+        $request = new Request();
+
+        $eventClass = \class_exists(ExceptionEvent::class) ? ExceptionEvent::class : GetResponseForExceptionEvent::class;
+        $event = new $eventClass($kernel, $request, HttpKernelInterface::SUB_REQUEST, $exception);
+
+        $listener = new ExceptionListener($interactor);
+        $listener->onKernelException($event);
+    }
+
+    public function testOnKernelExceptionWithHttp()
+    {
+        $exception = new BadRequestHttpException('Boom');
+
+        $interactor = $this->getMockBuilder(NewRelicInteractorInterface::class)->getMock();
+        $interactor->expects($this->never())->method('noticeThrowable');
+
+        $kernel = $this->getMockBuilder(HttpKernelInterface::class)->getMock();
+        $request = new Request();
+
+        $eventClass = \class_exists(ExceptionEvent::class) ? ExceptionEvent::class : GetResponseForExceptionEvent::class;
+        $event = new $eventClass($kernel, $request, HttpKernelInterface::SUB_REQUEST, $exception);
+
+        $listener = new ExceptionListener($interactor);
+        $listener->onKernelException($event);
+    }
+}

--- a/Tests/Listener/RequestListenerTest.php
+++ b/Tests/Listener/RequestListenerTest.php
@@ -19,7 +19,9 @@ use Ekino\NewRelicBundle\NewRelic\NewRelicInteractorInterface;
 use Ekino\NewRelicBundle\TransactionNamingStrategy\TransactionNamingStrategyInterface;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
+use Symfony\Component\HttpKernel\Event\ResponseEvent;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 
 class RequestListenerTest extends TestCase
@@ -32,9 +34,9 @@ class RequestListenerTest extends TestCase
         $namingStrategy = $this->getMockBuilder(TransactionNamingStrategyInterface::class)->getMock();
 
         $kernel = $this->getMockBuilder(HttpKernelInterface::class)->getMock();
-        $request = new Request();
 
-        $event = new GetResponseEvent($kernel, $request, HttpKernelInterface::SUB_REQUEST);
+        $eventClass = \class_exists(ResponseEvent::class) ? ResponseEvent::class : GetResponseEvent::class;
+        $event = new $eventClass($kernel, new Request(), HttpKernelInterface::SUB_REQUEST, new Response());
 
         $listener = new RequestListener(new Config('App name', 'Token'), $interactor, [], [], $namingStrategy);
         $listener->setApplicationName($event);
@@ -51,9 +53,9 @@ class RequestListenerTest extends TestCase
         $namingStrategy->expects($this->once())->method('getTransactionName')->willReturn('foobar');
 
         $kernel = $this->getMockBuilder(HttpKernelInterface::class)->getMock();
-        $request = new Request();
 
-        $event = new GetResponseEvent($kernel, $request, HttpKernelInterface::MASTER_REQUEST);
+        $eventClass = \class_exists(ResponseEvent::class) ? ResponseEvent::class : GetResponseEvent::class;
+        $event = new $eventClass($kernel, new Request(), HttpKernelInterface::MASTER_REQUEST, new Response());
 
         $listener = new RequestListener(new Config('App name', 'Token'), $interactor, [], [], $namingStrategy);
         $listener->setTransactionName($event);
@@ -69,7 +71,8 @@ class RequestListenerTest extends TestCase
         $kernel = $this->getMockBuilder(HttpKernelInterface::class)->getMock();
         $request = new Request([], [], [], [], [], ['REQUEST_URI' => '/ignored_path']);
 
-        $event = new GetResponseEvent($kernel, $request, HttpKernelInterface::MASTER_REQUEST);
+        $eventClass = \class_exists(ResponseEvent::class) ? ResponseEvent::class : GetResponseEvent::class;
+        $event = new $eventClass($kernel, $request, HttpKernelInterface::MASTER_REQUEST, new Response());
 
         $listener = new RequestListener(new Config('App name', 'Token'), $interactor, [], ['/ignored_path'], $namingStrategy);
         $listener->setIgnoreTransaction($event);
@@ -85,7 +88,8 @@ class RequestListenerTest extends TestCase
         $kernel = $this->getMockBuilder(HttpKernelInterface::class)->getMock();
         $request = new Request([], [], ['_route' => 'ignored_route']);
 
-        $event = new GetResponseEvent($kernel, $request, HttpKernelInterface::MASTER_REQUEST);
+        $eventClass = \class_exists(ResponseEvent::class) ? ResponseEvent::class : GetResponseEvent::class;
+        $event = new $eventClass($kernel, $request, HttpKernelInterface::MASTER_REQUEST, new Response());
 
         $listener = new RequestListener(new Config('App name', 'Token'), $interactor, ['ignored_route'], [], $namingStrategy);
         $listener->setIgnoreTransaction($event);
@@ -99,9 +103,9 @@ class RequestListenerTest extends TestCase
         $namingStrategy = $this->getMockBuilder(TransactionNamingStrategyInterface::class)->getMock();
 
         $kernel = $this->getMockBuilder(HttpKernelInterface::class)->getMock();
-        $request = new Request();
 
-        $event = new GetResponseEvent($kernel, $request, HttpKernelInterface::MASTER_REQUEST);
+        $eventClass = \class_exists(ResponseEvent::class) ? ResponseEvent::class : GetResponseEvent::class;
+        $event = new $eventClass($kernel, new Request(), HttpKernelInterface::MASTER_REQUEST, new Response());
 
         $listener = new RequestListener(new Config('App name', 'Token'), $interactor, [], [], $namingStrategy, true);
         $listener->setApplicationName($event);
@@ -115,9 +119,9 @@ class RequestListenerTest extends TestCase
         $namingStrategy = $this->getMockBuilder(TransactionNamingStrategyInterface::class)->getMock();
 
         $kernel = $this->getMockBuilder(HttpKernelInterface::class)->getMock();
-        $request = new Request();
 
-        $event = new GetResponseEvent($kernel, $request, HttpKernelInterface::MASTER_REQUEST);
+        $eventClass = \class_exists(ResponseEvent::class) ? ResponseEvent::class : GetResponseEvent::class;
+        $event = new $eventClass($kernel, new Request(), HttpKernelInterface::MASTER_REQUEST, new Response());
 
         $listener = new RequestListener(new Config('App name', 'Token'), $interactor, [], [], $namingStrategy, false);
         $listener->setApplicationName($event);

--- a/Tests/NewRelic/LoggingInteractorDecoratorTest.php
+++ b/Tests/NewRelic/LoggingInteractorDecoratorTest.php
@@ -30,9 +30,11 @@ class LoggingInteractorDecoratorTest extends TestCase
         $interactor = new LoggingInteractorDecorator($decorated, $logger);
 
         $logger->expects($this->once())->method('debug');
-        $decorated->expects($this->once())->method($method)
-            ->with(...$arguments)
-            ->willReturn($return);
+        $call = $decorated->expects($this->once())->method($method)
+            ->with(...$arguments);
+        if (null !== $return) {
+            $call->willReturn($return);
+        }
 
         $result = $interactor->$method(...$arguments);
 

--- a/Tests/Twig/NewRelicExtensionTest.php
+++ b/Tests/Twig/NewRelicExtensionTest.php
@@ -30,7 +30,7 @@ class NewRelicExtensionTest extends TestCase
      */
     private $interactor;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->newRelic = $this->getMockBuilder(Config::class)
         ->setMethods(['getCustomMetrics', 'getCustomParameters'])

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "symfony/http-kernel": "^3.4|^4.0|^5.0"
     },
     "require-dev": {
-        "matthiasnoback/symfony-dependency-injection-test": "^3.0",
+        "matthiasnoback/symfony-dependency-injection-test": "^3.0|^4.0",
         "nyholm/symfony-bundle-test": "^1.4",
         "symfony/phpunit-bridge": "^4.0|^5.0",
         "twig/twig": "^1.32|^2.4",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -8,7 +8,6 @@
          convertWarningsToExceptions="true"
          processIsolation="false"
          stopOnFailure="false"
-         syntaxCheck="false"
          bootstrap="vendor/autoload.php"
 >
     <testsuites>


### PR DESCRIPTION
Fix events renaming
- `FilterResponseEvent` => `ResponseEvent`
- `GetResponseEvent` => `ResponseEvent`
- `GetResponseForExceptionEvent` => `ExceptionEvent`

Bump `matthiasnoback/symfony-dependency-injection-test` to `^4.0` to allow symfony 5.0 in tests