### PR TITLE
Feature api host in config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## UNRELEASED
 
+### Added
+
+- Added `api_host` configuration property used by `NotifyDeploymentCommand`
+
 ## v2.1.3
 
 ### Added

--- a/Command/NotifyDeploymentCommand.php
+++ b/Command/NotifyDeploymentCommand.php
@@ -99,7 +99,7 @@ class NotifyDeploymentCommand extends Command
         return $exitCode;
     }
 
-    public function performRequest(string $api_key, string $payload, string $api_host = null): array
+    public function performRequest(string $api_key, string $payload, ?string $api_host = null): array
     {
         $headers = [
             \sprintf('x-api-key: %s', $api_key),

--- a/Command/NotifyDeploymentCommand.php
+++ b/Command/NotifyDeploymentCommand.php
@@ -74,7 +74,7 @@ class NotifyDeploymentCommand extends Command
         $exitCode = 0;
 
         foreach ($appNames as $appName) {
-            $response = $this->performRequest($this->newrelic->getApiHost(), $this->newrelic->getApiKey(), $this->createPayload($appName, $input));
+            $response = $this->performRequest($this->newrelic->getApiKey(), $this->createPayload($appName, $input), $this->newrelic->getApiHost());
 
             switch ($response['status']) {
                 case 200:
@@ -99,7 +99,7 @@ class NotifyDeploymentCommand extends Command
         return $exitCode;
     }
 
-    public function performRequest(string $api_host, string $api_key, string $payload): array
+    public function performRequest(string $api_key, string $payload, string $api_host = null): array
     {
         $headers = [
             \sprintf('x-api-key: %s', $api_key),
@@ -116,7 +116,7 @@ class NotifyDeploymentCommand extends Command
         ];
 
         $level = \error_reporting(0);
-        $content = \file_get_contents(\sprintf('https://%s/deployments.xml', $api_host), false, \stream_context_create($context));
+        $content = \file_get_contents(\sprintf('https://%s/deployments.xml', $api_host ?? 'api.newrelic.com'), false, \stream_context_create($context));
         \error_reporting($level);
         if (false === $content) {
             $error = \error_get_last();

--- a/Command/NotifyDeploymentCommand.php
+++ b/Command/NotifyDeploymentCommand.php
@@ -74,7 +74,7 @@ class NotifyDeploymentCommand extends Command
         $exitCode = 0;
 
         foreach ($appNames as $appName) {
-            $response = $this->performRequest($this->newrelic->getApiKey(), $this->createPayload($appName, $input));
+            $response = $this->performRequest($this->newrelic->getApiHost(), $this->newrelic->getApiKey(), $this->createPayload($appName, $input));
 
             switch ($response['status']) {
                 case 200:
@@ -99,7 +99,7 @@ class NotifyDeploymentCommand extends Command
         return $exitCode;
     }
 
-    public function performRequest(string $api_key, string $payload): array
+    public function performRequest(string $api_host, string $api_key, string $payload): array
     {
         $headers = [
             \sprintf('x-api-key: %s', $api_key),
@@ -116,7 +116,7 @@ class NotifyDeploymentCommand extends Command
         ];
 
         $level = \error_reporting(0);
-        $content = \file_get_contents('https://api.newrelic.com/deployments.xml', false, \stream_context_create($context));
+        $content = \file_get_contents(\sprintf('https://%s/deployments.xml', $api_host), false, \stream_context_create($context));
         \error_reporting($level);
         if (false === $content) {
             $error = \error_get_last();

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -37,7 +37,7 @@ class Configuration implements ConfigurationInterface
                 ->scalarNode('interactor')->end()
                 ->booleanNode('twig')->defaultValue(\class_exists(Environment::class))->end()
                 ->scalarNode('api_key')->defaultValue(null)->end()
-                ->scalarNode('api_host')->defaultValue('api.newrelic.com')->end()
+                ->scalarNode('api_host')->defaultValue(null)->end()
                 ->scalarNode('license_key')->defaultValue(null)->end()
                 ->scalarNode('application_name')->defaultValue(null)->end()
                 ->arrayNode('deployment_names')

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -37,6 +37,7 @@ class Configuration implements ConfigurationInterface
                 ->scalarNode('interactor')->end()
                 ->booleanNode('twig')->defaultValue(\class_exists(Environment::class))->end()
                 ->scalarNode('api_key')->defaultValue(null)->end()
+                ->scalarNode('api_host')->defaultValue('api.newrelic.com')->end()
                 ->scalarNode('license_key')->defaultValue(null)->end()
                 ->scalarNode('application_name')->defaultValue(null)->end()
                 ->arrayNode('deployment_names')

--- a/DependencyInjection/EkinoNewRelicExtension.php
+++ b/DependencyInjection/EkinoNewRelicExtension.php
@@ -71,6 +71,7 @@ class EkinoNewRelicExtension extends Extension
             ->setArguments(
                 [
                     '$name' => $config['application_name'],
+                    '$apiHost' => $config['api_host'],
                     '$apiKey' => $config['api_key'],
                     '$licenseKey' => $config['license_key'],
                     '$xmit' => $config['xmit'],

--- a/DependencyInjection/EkinoNewRelicExtension.php
+++ b/DependencyInjection/EkinoNewRelicExtension.php
@@ -71,11 +71,11 @@ class EkinoNewRelicExtension extends Extension
             ->setArguments(
                 [
                     '$name' => $config['application_name'],
-                    '$apiHost' => $config['api_host'],
                     '$apiKey' => $config['api_key'],
                     '$licenseKey' => $config['license_key'],
                     '$xmit' => $config['xmit'],
                     '$deploymentNames' => $config['deployment_names'],
+                    '$apiHost' => $config['api_host'],
                 ]
             );
 

--- a/NewRelic/Config.php
+++ b/NewRelic/Config.php
@@ -20,7 +20,7 @@ class Config
 {
     private $name;
     private $apiKey;
-    private $apiHost;
+    private $apiHost = null;
     private $licenseKey;
     private $xmit;
     private $customEvents;
@@ -28,7 +28,7 @@ class Config
     private $customParameters;
     private $deploymentNames;
 
-    public function __construct(?string $name, string $apiHost, string $apiKey = null, string $licenseKey = null, bool $xmit = false, array $deploymentNames = [])
+    public function __construct(?string $name, string $apiKey = null, string $licenseKey = null, bool $xmit = false, array $deploymentNames = [], ?string $apiHost = null)
     {
         $this->name = (!empty($name) ? $name : \ini_get('newrelic.appname')) ?: '';
         $this->apiKey = $apiKey;
@@ -107,7 +107,7 @@ class Config
         return $this->apiKey;
     }
 
-    public function getApiHost(): string
+    public function getApiHost(): ?string
     {
         return $this->apiHost;
     }

--- a/NewRelic/Config.php
+++ b/NewRelic/Config.php
@@ -20,6 +20,7 @@ class Config
 {
     private $name;
     private $apiKey;
+    private $apiHost;
     private $licenseKey;
     private $xmit;
     private $customEvents;
@@ -27,10 +28,11 @@ class Config
     private $customParameters;
     private $deploymentNames;
 
-    public function __construct(?string $name, string $apiKey = null, string $licenseKey = null, bool $xmit = false, array $deploymentNames = [])
+    public function __construct(?string $name, string $apiHost, string $apiKey = null, string $licenseKey = null, bool $xmit = false, array $deploymentNames = [])
     {
         $this->name = (!empty($name) ? $name : \ini_get('newrelic.appname')) ?: '';
         $this->apiKey = $apiKey;
+        $this->apiHost = $apiHost;
         $this->licenseKey = (!empty($licenseKey) ? $licenseKey : \ini_get('newrelic.license')) ?: '';
         $this->xmit = $xmit;
         $this->deploymentNames = $deploymentNames;
@@ -103,6 +105,11 @@ class Config
     public function getApiKey(): ?string
     {
         return $this->apiKey;
+    }
+
+    public function getApiHost(): string
+    {
+        return $this->apiHost;
     }
 
     public function getLicenseKey(): ?string

--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ ekino_new_relic:
                                           # as php ini-value
     deployment_names: ~                   # default value is 'application_name', supports string array or semi-colon separated string
     api_key:                              # New Relic API
+    api_host: ~                           # New Relic API Host (default value is api.newrelic.com, for EU should be set to api.eu.newrelic.com )
     license_key:                          # New Relic license key (optional, default value is read from php.ini)
     xmit: false                           # if you want to record the metric data up to the point newrelic_set_appname is called, set this to true (default: false)
     logging: false                        # If true, logs all New Relic interactions to the Symfony log (default: false)

--- a/Tests/NewRelic/ConfigTest.php
+++ b/Tests/NewRelic/ConfigTest.php
@@ -20,10 +20,11 @@ class ConfigTest extends TestCase
 {
     public function testGeneric()
     {
-        $newRelic = new Config('Ekino', 'XXX');
+        $newRelic = new Config('Ekino', 'api.host', 'XXX');
 
         $this->assertSame('Ekino', $newRelic->getName());
         $this->assertSame('XXX', $newRelic->getApiKey());
+        $this->assertSame('api.host', $newRelic->getApiHost());
 
         $this->assertEmpty($newRelic->getCustomEvents());
         $this->assertEmpty($newRelic->getCustomMetrics());

--- a/Tests/NewRelic/ConfigTest.php
+++ b/Tests/NewRelic/ConfigTest.php
@@ -20,7 +20,7 @@ class ConfigTest extends TestCase
 {
     public function testGeneric()
     {
-        $newRelic = new Config('Ekino', 'api.host', 'XXX');
+        $newRelic = new Config('Ekino', 'XXX', null, false, [], 'api.host');
 
         $this->assertSame('Ekino', $newRelic->getName());
         $this->assertSame('XXX', $newRelic->getApiKey());
@@ -76,5 +76,7 @@ class ConfigTest extends TestCase
 
         $this->assertNotNull($newRelic->getLicenseKey());
         $this->assertSame(\ini_get('newrelic.license') ?: '', $newRelic->getLicenseKey());
+
+        $this->assertNull($newRelic->getApiHost());
     }
 }


### PR DESCRIPTION
The API host was hardcoded and deployment notification did not work for the EU region datacenter, now it can be set by setting the api_host configuration property.

This fix closes the https://github.com/ekino/EkinoNewRelicBundle/issues/231 issue

