### PR TITLE
Fix class loaded twice

### DIFF
--- a/Listener/ExceptionListener.php
+++ b/Listener/ExceptionListener.php
@@ -51,8 +51,10 @@ class ExceptionListener implements EventSubscriberInterface
     }
 }
 
-if (\class_exists(ExceptionEvent::class)) {
-    \class_alias(ExceptionEvent::class, KernelExceptionEvent::class);
-} else {
-    \class_alias(GetResponseForExceptionEvent::class, KernelExceptionEvent::class);
+if (!\class_exists(KernelExceptionEvent::class)) {
+    if (\class_exists(ExceptionEvent::class)) {
+        \class_alias(ExceptionEvent::class, KernelExceptionEvent::class);
+    } else {
+        \class_alias(GetResponseForExceptionEvent::class, KernelExceptionEvent::class);
+    }
 }

--- a/Listener/RequestListener.php
+++ b/Listener/RequestListener.php
@@ -116,8 +116,10 @@ class RequestListener implements EventSubscriberInterface
     }
 }
 
-if (\class_exists(RequestEvent::class)) {
-    \class_alias(RequestEvent::class, KernelRequestEvent::class);
-} else {
-    \class_alias(GetResponseEvent::class, KernelRequestEvent::class);
+if (!\class_exists(KernelRequestEvent::class)) {
+    if (\class_exists(RequestEvent::class)) {
+        \class_alias(RequestEvent::class, KernelRequestEvent::class);
+    } else {
+        \class_alias(GetResponseEvent::class, KernelRequestEvent::class);
+    }
 }

--- a/Listener/ResponseListener.php
+++ b/Listener/ResponseListener.php
@@ -110,8 +110,10 @@ class ResponseListener implements EventSubscriberInterface
     }
 }
 
-if (\class_exists(ResponseEvent::class)) {
-    \class_alias(ResponseEvent::class, KernelResponseEvent::class);
-} else {
-    \class_alias(FilterResponseEvent::class, KernelResponseEvent::class);
+if (!\class_exists(KernelResponseEvent::class)) {
+    if (\class_exists(ResponseEvent::class)) {
+        \class_alias(ResponseEvent::class, KernelResponseEvent::class);
+    } else {
+        \class_alias(FilterResponseEvent::class, KernelResponseEvent::class);
+    }
 }


### PR DESCRIPTION
With PHP 7.4 and preloading, peple reported the following error:

Noticed exception 'ErrorException' with message 'Warning: Cannot declare class Ekino\NewRelicBundle\Listener\KernelExceptionEvent, because the name is already in use' in /app/vendor/ekino/newrelic-bundle/Listener/ExceptionListener.php:55



I guess it happens when the class `KernelExceptionEvent` exists (in cache) but not the ExceptionListener.
This PR checks if the class already exists before creating the alias