### PR TITLE
Execute the callable in BlackholeInteractor

### DIFF
--- a/NewRelic/BlackholeInteractor.php
+++ b/NewRelic/BlackholeInteractor.php
@@ -113,6 +113,7 @@ class BlackholeInteractor implements NewRelicInteractorInterface
 
     public function recordDatastoreSegment(callable $func, array $parameters)
     {
+        return $func();
     }
 
     public function setUserAttributes(string $userValue, string $accountValue, string $productValue): bool


### PR DESCRIPTION
Hello 👋 😃 

According to the [documentation of `newrelic_record_datastore_segment`](https://docs.newrelic.com/docs/agents/php-agent/php-agent-api/newrelic_record_datastore_segment), this function has to execute the callable passed in argument. So when I use the method `NewRelicInteractorInterface::recordDatastoreSegment(callable $func, array $parameters)` I expect `$func` will be executed and to retrieve the result, **whatever** the concrete implementation. 

Unfortunately, with the `BlackholeInteractor` nothing is done… Since the purpose of this callable is to perform the actual database operation, it means that with the `BlackholeInteractor` nothing will be actually done with the database 😨 .

I propose this patch, but we can imagine an other interactor If are worrying about BC breaks.
Let me know what do you think about it!
Thanks a lot for your work on this great library 🙏 
Have a nice day 😄 
