### PR TITLE
Fix error when you leave license empty in setApplicationName.

### DIFF
--- a/NewRelic/NewRelicInteractor.php
+++ b/NewRelic/NewRelicInteractor.php
@@ -17,6 +17,9 @@ class NewRelicInteractor implements NewRelicInteractorInterface
 {
     public function setApplicationName(string $name, string $license = null, bool $xmit = false): bool
     {
+        if (null === $license) {
+            return newrelic_set_appname($name);
+        }
         return newrelic_set_appname($name, $license, $xmit);
     }
 


### PR DESCRIPTION
Hi,

When you only fill in the name and keeping the rest empty in setApplicationName, you will receive an error: `newrelic_set_appname() expects parameter 2 to be string, null given`. By adding this check and only passing through name variable the issue is solved.