### PR TITLE
Fixed incorrect namespace in ControllerNamingStrategyTest

### DIFF
--- a/Tests/TransactionNamingStrategy/ControllerNamingStrategyTest.php
+++ b/Tests/TransactionNamingStrategy/ControllerNamingStrategyTest.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace Ekino\NewRelicBundle\TransactionNamingStrategy;
+namespace Ekino\NewRelicBundle\Tests\TransactionNamingStrategy;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;


### PR DESCRIPTION
Fixes a warning in `composer dump-autoload`

```
Class Ekino\Bundle\NewRelicBundle\TransactionNamingStrategy\ControllerNamingStrategyTest located in ./vendor/ekino/newrelic-bundle/Tests/TransactionNamingStrategy/ControllerNamingStrategyTest.php does not comply with psr-4 autoloading standard. Skipping.
```