### PR TITLE
Make recordDatastoreSegment execute the callback

### DIFF
--- a/NewRelic/BlackholeInteractor.php
+++ b/NewRelic/BlackholeInteractor.php
@@ -113,6 +113,7 @@ class BlackholeInteractor implements NewRelicInteractorInterface
 
     public function recordDatastoreSegment(callable $func, array $parameters)
     {
+        return $func()
     }
 
     public function setUserAttributes(string $userValue, string $accountValue, string $productValue): bool


### PR DESCRIPTION
the function `newrelic_record_datastore_segment()` will call the provided callback.

To provide the same functionality and not to brake code in environment that don't have the newrelic module installed, the callback will now be called.