### PR TITLE
Distributed traces > Pass $headers by reference

### DIFF
--- a/NewRelic/AdaptiveInteractor.php
+++ b/NewRelic/AdaptiveInteractor.php
@@ -167,7 +167,7 @@ class AdaptiveInteractor implements NewRelicInteractorInterface
         return $this->interactor->isSampled();
     }
 
-    public function insertDistributedTracingHeaders(array $headers): void
+    public function insertDistributedTracingHeaders(array &$headers): void
     {
         if (!method_exists($this->interactor, 'insertDistributedTracingHeaders')) {
             throw new \BadMethodCallException('The decorated interaction does not implement this method');

--- a/NewRelic/BlackholeInteractor.php
+++ b/NewRelic/BlackholeInteractor.php
@@ -136,7 +136,7 @@ class BlackholeInteractor implements NewRelicInteractorInterface
         return true;
     }
 
-    public function insertDistributedTracingHeaders(array $headers): void
+    public function insertDistributedTracingHeaders(array &$headers): void
     {
     }
 

--- a/NewRelic/LoggingInteractorDecorator.php
+++ b/NewRelic/LoggingInteractorDecorator.php
@@ -212,7 +212,7 @@ class LoggingInteractorDecorator implements NewRelicInteractorInterface
         return $isSampled;
     }
 
-    public function insertDistributedTracingHeaders(array $headers): void
+    public function insertDistributedTracingHeaders(array &$headers): void
     {
         $this->logger->debug('Setting New Relic distributed tracing headers', ['headers' => $headers]);
 

--- a/NewRelic/NewRelicInteractor.php
+++ b/NewRelic/NewRelicInteractor.php
@@ -155,7 +155,7 @@ class NewRelicInteractor implements NewRelicInteractorInterface
         return newrelic_is_sampled();
     }
 
-    public function insertDistributedTracingHeaders(array $headers): void
+    public function insertDistributedTracingHeaders(array &$headers): void
     {
         if (!function_exists('newrelic_insert_distributed_trace_headers')) {
             throw new \BadMethodCallException('You need the "newrelic" extension version 9.8 or higher to use this method');

--- a/NewRelic/NewRelicInteractorInterface.php
+++ b/NewRelic/NewRelicInteractorInterface.php
@@ -19,7 +19,7 @@ namespace Ekino\NewRelicBundle\NewRelic;
  * @method array getTraceMetadata()
  * @method array getLinkingMetadata()
  * @method bool isSampled()
- * @method void insertDistributedTracingHeaders(array $headers)
+ * @method void insertDistributedTracingHeaders(array &$headers)
  * @method void acceptDistributedTraceHeaders(array $headers, string $transportType = 'HTTP')
  */
 interface NewRelicInteractorInterface


### PR DESCRIPTION
Because the New Relic extension will fill the values in that
array. If it's not passed by reference, the variable is copied.