### PR TITLE
fix: addCustomParameter() must be of the type string, int given

### DIFF
--- a/Listener/CommandListener.php
+++ b/Listener/CommandListener.php
@@ -77,7 +77,7 @@ class CommandListener implements EventSubscriberInterface
                     $this->interactor->addCustomParameter($key.'['.$k.']', $v);
                 }
             } else {
-                $this->interactor->addCustomParameter($key, $value);
+                $this->interactor->addCustomParameter((string) $key, $value);
             }
         }
     }


### PR DESCRIPTION
Currently `$key` on line 80 of `Listener/CommandListener.php` is the only location in which it isn't implicitly cast to a string.
Hence we should use an explicit cast to ensure the type requirement for the argument is fulfilled.