### PR TITLE
Fix deprecated `$defaultName`

### DIFF
--- a/Command/NotifyDeploymentCommand.php
+++ b/Command/NotifyDeploymentCommand.php
@@ -25,8 +25,6 @@ class NotifyDeploymentCommand extends Command
     public const EXIT_UNAUTHORIZED = 2;
     public const EXIT_HTTP_ERROR = 3;
 
-    protected static $defaultName = 'newrelic:notify-deployment';
-
     private $newrelic;
 
     public function __construct(Config $newrelic)

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -10,6 +10,10 @@
         <prototype namespace="Ekino\NewRelicBundle\NewRelic\" resource="../../NewRelic/*" />
         <prototype namespace="Ekino\NewRelicBundle\TransactionNamingStrategy\" resource="../../TransactionNamingStrategy/*" />
 
+        <service id="Ekino\NewRelicBundle\Command\NotifyDeploymentCommand" autowire="true" autoconfigure="true">
+            <tag name="console.command" command="newrelic:notify-deployment" />
+        </service>
+
         <service id="Ekino\NewRelicBundle\NewRelic\AdaptiveInteractor">
             <argument type="service" id="Ekino\NewRelicBundle\NewRelic\NewRelicInteractor" />
             <argument type="service" id="Ekino\NewRelicBundle\NewRelic\BlackholeInteractor" />


### PR DESCRIPTION
This fixes a deprecation on Symfony 6.1:
The "Symfony\Component\Console\Command\Command::$defaultName" property is considered final. You should not override it in "Ekino\NewRelicBundle\Command\NotifyDeploymentCommand".

We cannot use `#[AsCommand]` as that will still complain about the `$defaultName` being overwritten... and we have to support SF 3.4.