### PR TITLE
Support PHP 8.1 and Symfony 6.1 (limiting BC to PHP 7.2)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
   pull_request: ~
   push:
     branches:
-      - master
+      - patch-1
 
 jobs:
   php-cs-fixer:
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['7.1', '7.2', '7.3', '7.4', '8.0']
+        php: ['7.1', '7.2', '7.3', '7.4', '8.0', '8.1']
         composer: ['']
         phpunit: ['']
         deprecation: ['']
@@ -29,7 +29,7 @@ jobs:
         stability: ['']
         include:
           # Minimum supported dependencies with the latest and oldest PHP version
-          - php: 8.0
+          - php: 8.1
             composer: --prefer-stable --prefer-lowest
             deprecation: max[direct]=0
           - php: 7.1
@@ -37,15 +37,15 @@ jobs:
             deprecation: max[direct]=0
 
           # symfony version
-          - php: 8.0
+          - php: 8.1
             symfony: '^3.0'
-          - php: 8.0
+          - php: 8.1
             symfony: '^4.0'
-          - php: 8.0
+          - php: 8.1
             symfony: '^5.0'
 
           # dev
-          - php: 8.0
+          - php: 8.1
             stability: 'dev'
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['7.1', '7.2', '7.3', '7.4', '8.0', '8.1']
+        php: ['8.1']
         composer: ['']
         phpunit: ['']
         deprecation: ['']
@@ -30,9 +30,6 @@ jobs:
         include:
           # Minimum supported dependencies with the latest and oldest PHP version
           - php: 8.1
-            composer: --prefer-stable --prefer-lowest
-            deprecation: max[direct]=0
-          - php: 7.1
             composer: --prefer-stable --prefer-lowest
             deprecation: max[direct]=0
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
   pull_request: ~
   push:
     branches:
-      - patch-1-1
+      - master
 
 jobs:
   php-cs-fixer:
@@ -22,7 +22,6 @@ jobs:
       fail-fast: false
       matrix:
         php: ['7.2', '7.3', '7.4', '8.0', '8.1']
-        composer-version: ['']
         composer: ['']
         phpunit: ['']
         deprecation: ['']
@@ -38,11 +37,11 @@ jobs:
             deprecation: max[direct]=0
 
           # symfony version
+          - php: 8.0
+            symfony: '^3.0'
           - php: 8.1
             symfony: '^3.0'
             deprecation: max[self]=0 # since Symfony 3 itself causes them...
-          - php: 8.0
-            symfony: '^3.0'
           - php: 8.1
             symfony: '^4.0'
           - php: 8.1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,11 +17,12 @@ jobs:
 
   build:
     name: Build
-    runs-on: Ubuntu-20.04
+    runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
       matrix:
-        php: ['8.1']
+        php: ['7.1, '7.2', '7.3', '7.4', '8.0', '8.1']
+        composer-version: ['']
         composer: ['']
         phpunit: ['']
         deprecation: ['']
@@ -30,6 +31,9 @@ jobs:
         include:
           # Minimum supported dependencies with the latest and oldest PHP version
           - php: 8.1
+            composer: --prefer-stable --prefer-lowest
+            deprecation: max[direct]=0
+          - php: 7.1
             composer: --prefer-stable --prefer-lowest
             deprecation: max[direct]=0
 
@@ -68,6 +72,11 @@ jobs:
         if: matrix.symfony != ''
         run: |
           echo 'SYMFONY_REQUIRE=${{ matrix.symfony }}' >> $GITHUB_ENV
+
+      - name: Rollback Composer to 2.2 LTS
+        if: matrix.php == '7.1'
+        run: |
+          composer self-update --2.2
 
       - name: Download dependencies
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['7.1, '7.2', '7.3', '7.4', '8.0', '8.1']
+        php: ['7.2', '7.3', '7.4', '8.0', '8.1']
         composer-version: ['']
         composer: ['']
         phpunit: ['']
@@ -29,16 +29,24 @@ jobs:
         symfony: ['']
         stability: ['']
         include:
+          # Force Composer 2.2 LTS for PHP 7.1 support
+          - php: 7.1
+            composer-version: :2.2
+
           # Minimum supported dependencies with the latest and oldest PHP version
           - php: 8.1
             composer: --prefer-stable --prefer-lowest
             deprecation: max[direct]=0
           - php: 7.1
+            composer-version: :2.2
             composer: --prefer-stable --prefer-lowest
             deprecation: max[direct]=0
 
           # symfony version
           - php: 8.1
+            symfony: '^3.0'
+            deprecation: max[self]=0 # since Symfony 3 itself causes them...
+          - php: 8.0
             symfony: '^3.0'
           - php: 8.1
             symfony: '^4.0'
@@ -51,11 +59,11 @@ jobs:
 
     steps:
       - name: Set up PHP
-        uses: shivammathur/setup-php@2.7.0
+        uses: shivammathur/setup-php@2.18.1
         with:
           php-version: ${{ matrix.php }}
           coverage: none
-          tools: flex
+          tools: flex, composer${{ matrix.composer-version }}
 
       - name: Checkout code
         uses: actions/checkout@v2
@@ -72,11 +80,6 @@ jobs:
         if: matrix.symfony != ''
         run: |
           echo 'SYMFONY_REQUIRE=${{ matrix.symfony }}' >> $GITHUB_ENV
-
-      - name: Rollback Composer to 2.2 LTS
-        if: matrix.php == '7.1'
-        run: |
-          composer self-update --2.2
 
       - name: Download dependencies
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
   pull_request: ~
   push:
     branches:
-      - patch-1
+      - patch-1-1
 
 jobs:
   php-cs-fixer:
@@ -29,16 +29,11 @@ jobs:
         symfony: ['']
         stability: ['']
         include:
-          # Force Composer 2.2 LTS for PHP 7.1 support
-          - php: 7.1
-            composer-version: :2.2
-
           # Minimum supported dependencies with the latest and oldest PHP version
           - php: 8.1
             composer: --prefer-stable --prefer-lowest
             deprecation: max[direct]=0
-          - php: 7.1
-            composer-version: :2.2
+          - php: 7.2
             composer: --prefer-stable --prefer-lowest
             deprecation: max[direct]=0
 
@@ -59,11 +54,11 @@ jobs:
 
     steps:
       - name: Set up PHP
-        uses: shivammathur/setup-php@2.18.1
+        uses: shivammathur/setup-php@2.7.0
         with:
           php-version: ${{ matrix.php }}
           coverage: none
-          tools: flex, composer${{ matrix.composer-version }}
+          tools: flex
 
       - name: Checkout code
         uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['7.2', '7.3', '7.4', '8.0', '8.1']
+        php: ['7.1', '7.2', '7.3', '7.4', '8.0', '8.1']
         composer: ['']
         phpunit: ['']
         deprecation: ['']
@@ -32,7 +32,7 @@ jobs:
           - php: 8.1
             composer: --prefer-stable --prefer-lowest
             deprecation: max[direct]=0
-          - php: 7.2
+          - php: 7.1
             composer: --prefer-stable --prefer-lowest
             deprecation: max[direct]=0
 

--- a/Command/NotifyDeploymentCommand.php
+++ b/Command/NotifyDeploymentCommand.php
@@ -25,8 +25,6 @@ class NotifyDeploymentCommand extends Command
     public const EXIT_UNAUTHORIZED = 2;
     public const EXIT_HTTP_ERROR = 3;
 
-    protected static $defaultName = 'newrelic:notify-deployment';
-
     private $newrelic;
 
     public function __construct(Config $newrelic)

--- a/Command/NotifyDeploymentCommand.php
+++ b/Command/NotifyDeploymentCommand.php
@@ -14,18 +14,18 @@ declare(strict_types=1);
 namespace Ekino\NewRelicBundle\Command;
 
 use Ekino\NewRelicBundle\NewRelic\Config;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
+#[AsCommand(name: 'newrelic:notify-deployment')]
 class NotifyDeploymentCommand extends Command
 {
     public const EXIT_NO_APP_NAMES = 1;
     public const EXIT_UNAUTHORIZED = 2;
     public const EXIT_HTTP_ERROR = 3;
-
-    protected static $defaultName = 'newrelic:notify-deployment';
 
     private $newrelic;
 

--- a/Command/NotifyDeploymentCommand.php
+++ b/Command/NotifyDeploymentCommand.php
@@ -14,18 +14,18 @@ declare(strict_types=1);
 namespace Ekino\NewRelicBundle\Command;
 
 use Ekino\NewRelicBundle\NewRelic\Config;
-use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
-#[AsCommand(name: 'newrelic:notify-deployment')]
 class NotifyDeploymentCommand extends Command
 {
     public const EXIT_NO_APP_NAMES = 1;
     public const EXIT_UNAUTHORIZED = 2;
     public const EXIT_HTTP_ERROR = 3;
+
+    protected static $defaultName = 'newrelic:notify-deployment';
 
     private $newrelic;
 

--- a/Logging/AdaptiveHandler.php
+++ b/Logging/AdaptiveHandler.php
@@ -29,9 +29,6 @@ class AdaptiveHandler extends NewRelicHandler
         parent::__construct($level, $bubble, $appName, $explodeArrays, $transactionName);
     }
 
-    /**
-     * @inheritDoc
-     */
     protected function write($record): void
     {
         if (!$this->isNewRelicEnabled()) {

--- a/Logging/AdaptiveHandler.php
+++ b/Logging/AdaptiveHandler.php
@@ -29,7 +29,10 @@ class AdaptiveHandler extends NewRelicHandler
         parent::__construct($level, $bubble, $appName, $explodeArrays, $transactionName);
     }
 
-    protected function write(LogRecord $record): void
+    /**
+     * @inheritDoc
+     */
+    protected function write($record): void
     {
         if (!$this->isNewRelicEnabled()) {
             return;

--- a/Logging/AdaptiveHandler.php
+++ b/Logging/AdaptiveHandler.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Ekino\NewRelicBundle\Logging;
 
 use Monolog\Handler\NewRelicHandler;
+use Monolog\LogRecord;
 use Psr\Log\LogLevel;
 
 class AdaptiveHandler extends NewRelicHandler
@@ -28,7 +29,7 @@ class AdaptiveHandler extends NewRelicHandler
         parent::__construct($level, $bubble, $appName, $explodeArrays, $transactionName);
     }
 
-    protected function write(array $record): void
+    protected function write(LogRecord $record): void
     {
         if (!$this->isNewRelicEnabled()) {
             return;

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -10,6 +10,10 @@
         <prototype namespace="Ekino\NewRelicBundle\NewRelic\" resource="../../NewRelic/*" />
         <prototype namespace="Ekino\NewRelicBundle\TransactionNamingStrategy\" resource="../../TransactionNamingStrategy/*" />
 
+        <service id="Ekino\NewRelicBundle\Command\NotifyDeploymentCommand" autowire="true" autoconfigure="true">
+            <tag name="console.command" command="newrelic:notify-deployment" />
+        </service>
+
         <service id="Ekino\NewRelicBundle\NewRelic\AdaptiveInteractor">
             <argument type="service" id="Ekino\NewRelicBundle\NewRelic\NewRelicInteractor" />
             <argument type="service" id="Ekino\NewRelicBundle\NewRelic\BlackholeInteractor" />

--- a/Tests/AppKernel.php
+++ b/Tests/AppKernel.php
@@ -98,6 +98,7 @@ class AppKernel extends Kernel
                     'resource' => 'kernel:loadRoutes',
                     'type' => 'service',
                 ],
+                'http_method_override' => false,
             ]);
 
             // Not setting the router to utf8 is deprecated in symfony 5.1

--- a/Tests/AppKernel.php
+++ b/Tests/AppKernel.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 namespace Ekino\NewRelicBundle\Tests;
 
 use Ekino\NewRelicBundle\EkinoNewRelicBundle;
-use Exception;
 use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
 use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
@@ -162,7 +161,7 @@ class AppKernel extends Kernel
     }
 
     /**
-     * @throws Exception
+     * @throws \Exception
      */
     public function __serialize(): array
     {

--- a/Tests/AppKernel.php
+++ b/Tests/AppKernel.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Ekino\NewRelicBundle\Tests;
 
 use Ekino\NewRelicBundle\EkinoNewRelicBundle;
+use Exception;
 use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
 use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
@@ -158,5 +159,18 @@ class AppKernel extends Kernel
         });
 
         return $container;
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function __serialize(): array
+    {
+        return unserialize($this->serialize());
+    }
+
+    public function __unserialize(array $data): void
+    {
+        $this->unserialize(serialize($data));
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "symfony/http-kernel": "^3.4|^4.0|^5.0|^6.0"
     },
     "require-dev": {
-        "matthiasnoback/symfony-dependency-injection-test": "^3.1|^4.0",
+        "matthiasnoback/symfony-dependency-injection-test": "^4.0",
         "symfony/framework-bundle": "^3.4|^4.0|^5.0|^6.0",
         "symfony/phpunit-bridge": "^5.3",
         "symfony/debug": ">3.4.21",

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         }
     ],
     "require": {
-        "php": "^7.1 | ^8.0",
+        "php": "^7.2 | ^8.0",
         "symfony/config": "^3.4|^4.0|^5.0|^6.0",
         "symfony/console": "^3.4|^4.0|^5.0|^6.0",
         "symfony/dependency-injection": "^3.4|^4.0|^5.0|^6.0",

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         }
     ],
     "require": {
-        "php": "^7.1 | ^8.0",
+        "php": "^8.1",
         "symfony/config": "^3.4|^4.0|^5.0|^6.0",
         "symfony/console": "^3.4|^4.0|^5.0|^6.0",
         "symfony/dependency-injection": "^3.4|^4.0|^5.0|^6.0",
@@ -29,7 +29,8 @@
         "symfony/monolog-bundle": "^3.2"
     },
     "conflict": {
-        "twig/twig": "<1.32"
+        "twig/twig": "<1.32",
+        "monolog/monolog": "<3.0"
     },
     "suggest": {
         "symfony/monolog-bundle": "^3.2"

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         }
     ],
     "require": {
-        "php": "^7.2 | ^8.0",
+        "php": "^7.1 | ^8.0",
         "symfony/config": "^3.4|^4.0|^5.0|^6.0",
         "symfony/console": "^3.4|^4.0|^5.0|^6.0",
         "symfony/dependency-injection": "^3.4|^4.0|^5.0|^6.0",

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         }
     ],
     "require": {
-        "php": "^8.1",
+        "php": "^7.1 | ^8.0",
         "symfony/config": "^3.4|^4.0|^5.0|^6.0",
         "symfony/console": "^3.4|^4.0|^5.0|^6.0",
         "symfony/dependency-injection": "^3.4|^4.0|^5.0|^6.0",
@@ -29,8 +29,7 @@
         "symfony/monolog-bundle": "^3.2"
     },
     "conflict": {
-        "twig/twig": "<1.32",
-        "monolog/monolog": "<3.0"
+        "twig/twig": "<1.32"
     },
     "suggest": {
         "symfony/monolog-bundle": "^3.2"

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,18 +1,30 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" backupGlobals="false" backupStaticAttributes="false" colors="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" processIsolation="false" stopOnFailure="false" bootstrap="vendor/autoload.php" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
-  <coverage>
-    <include>
-      <directory>./</directory>
-    </include>
-    <exclude>
-      <directory>./Tests/</directory>
-      <directory>./Resources/</directory>
-      <directory>./vendor/</directory>
-    </exclude>
-  </coverage>
-  <testsuites>
-    <testsuite name="Ekino New Relic Test Suite">
-      <directory>./Tests</directory>
-    </testsuite>
-  </testsuites>
+
+<phpunit backupGlobals="false"
+         backupStaticAttributes="false"
+         colors="true"
+         convertErrorsToExceptions="true"
+         convertNoticesToExceptions="true"
+         convertWarningsToExceptions="true"
+         processIsolation="false"
+         stopOnFailure="false"
+         bootstrap="vendor/autoload.php"
+>
+    <testsuites>
+        <testsuite name="Ekino New Relic Test Suite">
+            <directory>./Tests</directory>
+        </testsuite>
+    </testsuites>
+
+    <filter>
+        <whitelist>
+            <directory>./</directory>
+            <exclude>
+                <directory>./Tests/</directory>
+                <directory>./Resources/</directory>
+                <directory>./vendor/</directory>
+            </exclude>
+        </whitelist>
+    </filter>
+
 </phpunit>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,30 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
-<phpunit backupGlobals="false"
-         backupStaticAttributes="false"
-         colors="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
-         processIsolation="false"
-         stopOnFailure="false"
-         bootstrap="vendor/autoload.php"
->
-    <testsuites>
-        <testsuite name="Ekino New Relic Test Suite">
-            <directory>./Tests</directory>
-        </testsuite>
-    </testsuites>
-
-    <filter>
-        <whitelist>
-            <directory>./</directory>
-            <exclude>
-                <directory>./Tests/</directory>
-                <directory>./Resources/</directory>
-                <directory>./vendor/</directory>
-            </exclude>
-        </whitelist>
-    </filter>
-
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" backupGlobals="false" backupStaticAttributes="false" colors="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" processIsolation="false" stopOnFailure="false" bootstrap="vendor/autoload.php" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory>./</directory>
+    </include>
+    <exclude>
+      <directory>./Tests/</directory>
+      <directory>./Resources/</directory>
+      <directory>./vendor/</directory>
+    </exclude>
+  </coverage>
+  <testsuites>
+    <testsuite name="Ekino New Relic Test Suite">
+      <directory>./Tests</directory>
+    </testsuite>
+  </testsuites>
 </phpunit>


### PR DESCRIPTION
This fixes deprecations and compilation failures with Symfony 6.1 (thanks to @ruudk for their fork) and PHP 8.1, mainly revolving around Monolog's `AbstractProcessingHandler::write` changed signature.

It's worthy of note that:
-  Monolog [dropped support for versions earlier than 8.1 at the same time they changed it](https://github.com/Seldaek/monolog/commit/22c8b19358e916c52f1d2170d44e172152de7c25), and because of the new signature, it would require a good amount of botching to make [`AdaptiveHandler`](https://github.com/CRC-Mismatch/EkinoNewRelicBundle/runs/6681138639?check_suite_focus=true#step:9:110) work for both previous and current versions [as is in PHP 7.1](https://github.com/CRC-Mismatch/EkinoNewRelicBundle/runs/6682501159?check_suite_focus=true#step:9:103), while this PR's proposed solution passes all tests in PHP >= 7.2.
- Composer [dropped support for versions earlier than PHP 7.2 in 2.3](https://github.com/ekino/EkinoNewRelicBundle/runs/6626357186?check_suite_focus=true#step:7:6), requiring a downgrade to Composer 2.2 LTS in CI to keep it from failing before even trying to resolve dependencies.

That being said, this is basically the easy (and AFAIK the only sane) way out - dropping support for PHP 7.1. If that is not satisfying, I will try to find a way to support both PHP 7.1 and 8.1 without limiting monolog to `<3.0` later this week, but I can already tell it's not going to be a quick (nor pretty) job...

If PHP 7.1 support is really a must, I would suggest keeping a separate branch with monolog's version locked and split this PR into a new major version.

The CI pass evidence (apart from the latter [changes to `ci.yml` rearranging the matrix and reverting the branch trigger](https://github.com/ekino/EkinoNewRelicBundle/compare/8e0213e0de55825e0d45e24c4645eb2a3ea99483..2077b59beedacd9438e8a1b08ae352af1e935551)) is already available [here](https://github.com/CRC-Mismatch/EkinoNewRelicBundle/actions/runs/2419351072).