### PR TITLE
Change AdaptiveHandler::write() argument type and update monolog/monolog requirement

### DIFF
--- a/Logging/AdaptiveHandler.php
+++ b/Logging/AdaptiveHandler.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Ekino\NewRelicBundle\Logging;
 
 use Monolog\Handler\NewRelicHandler;
+use Monolog\LogRecord;
 use Psr\Log\LogLevel;
 
 class AdaptiveHandler extends NewRelicHandler
@@ -28,7 +29,7 @@ class AdaptiveHandler extends NewRelicHandler
         parent::__construct($level, $bubble, $appName, $explodeArrays, $transactionName);
     }
 
-    protected function write(array $record): void
+    protected function write(LogRecord $record): void
     {
         if (!$this->isNewRelicEnabled()) {
             return;

--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,7 @@
     ],
     "require": {
         "php": "^7.1 | ^8.0",
+        "monolog/monolog": "^3.0",
         "symfony/config": "^3.4|^4.0|^5.0|^6.0",
         "symfony/console": "^3.4|^4.0|^5.0|^6.0",
         "symfony/dependency-injection": "^3.4|^4.0|^5.0|^6.0",


### PR DESCRIPTION
When using the newrelic bundle on Symfony 6.2 and PHP 8.1 I get the following error:

> Fatal error: Declaration of Ekino\NewRelicBundle\Logging\AdaptiveHandler::write(array $record): void must be compatible with Monolog\Handler\NewRelicHandler::write(Monolog\LogRecord $record): void in /var/www/html/vendor/ekino/newrelic-bundle/Logging/AdaptiveHandler.php on line 31

Since monolog/monolog `v3.0.0` the argument type was changed from `array` to `LogRecord` (see: https://github.com/Seldaek/monolog/blame/main/src/Monolog/Handler/NewRelicHandler.php#L60).

I updated the argument type, as well as the required version of `monolog/monolog` since the need to be compatible, it requires version `v3.0.0`.

Note I also reviewed that PR https://github.com/ekino/EkinoNewRelicBundle/pull/281 but I introduce less changes in the hope to fix that specific issue.